### PR TITLE
Fix pack() and unpack() bugs.

### DIFF
--- a/2012/10/29/storeload.cpp
+++ b/2012/10/29/storeload.cpp
@@ -140,30 +140,32 @@ int testStoreLoadC(size_t M =  2048 * 4, size_t N = 2048 * 8, size_t repeat = 1)
 __attribute__ ((noinline)) 
 void pack(bool * uncompressed, char * compressed, size_t N) {
 	int bogus = 0;
-	for(size_t x = 0; x+7<N; x+=8) {
-		compressed[x] = uncompressed[x] | 
-		uncompressed[x+1]<<1 |
-		uncompressed[x+2]<<2 |
-		uncompressed[x+3]<<3 |
-		uncompressed[x+4]<<4 |
-		uncompressed[x+5]<<5 |
-		uncompressed[x+6]<<6 |
-		uncompressed[x+7]<<7 ;
+	for(size_t i = 0; i < N/8; ++i) {
+		size_t x = i * 8;
+		compressed[i] = uncompressed[x] | 
+		                uncompressed[x+1]<<1 |
+		                uncompressed[x+2]<<2 |
+		                uncompressed[x+3]<<3 |
+		                uncompressed[x+4]<<4 |
+		                uncompressed[x+5]<<5 |
+		                uncompressed[x+6]<<6 |
+		                uncompressed[x+7]<<7 ;
 	}
 }
 
 __attribute__ ((noinline)) 
 void unpack(char * compressed, bool * uncompressed, size_t N) {
 	int bogus = 0;
-	for(size_t x = 0; x+7<N; x+=8) {
-		uncompressed[x] = compressed[x] & 1;
-		uncompressed[x+1] = compressed[x] & (1<<1);
-		uncompressed[x+2] = compressed[x] & (1<<2);
-		uncompressed[x+3] = compressed[x] & (1<<3);
-		uncompressed[x+4] = compressed[x] & (1<<4);
-		uncompressed[x+5] = compressed[x] & (1<<5);
-		uncompressed[x+6] = compressed[x] & (1<<6);
-		uncompressed[x+7] = compressed[x] & (1<<7);
+	for(size_t i = 0; i < N/8; ++i) {
+		size_t x = i * 8;
+		uncompressed[x]   = compressed[i] & 1;
+		uncompressed[x+1] = compressed[i] & (1<<1);
+		uncompressed[x+2] = compressed[i] & (1<<2);
+		uncompressed[x+3] = compressed[i] & (1<<3);
+		uncompressed[x+4] = compressed[i] & (1<<4);
+		uncompressed[x+5] = compressed[i] & (1<<5);
+		uncompressed[x+6] = compressed[i] & (1<<6);
+		uncompressed[x+7] = compressed[i] & (1<<7);
 	}
 }
 
@@ -176,10 +178,10 @@ void testPackUnpackC(size_t N =  2048 * 32 * 2048) {
 	vector<char> comp(N/8);
 	for(size_t t = 0; t< 3; ++t) {
 		timer.reset();
-		pack(data,&comp[0],N/8);
+		pack(data, &comp[0], N);
 		cout<<" pack time = "<<timer.split()<<endl;
 		timer.reset();
-		unpack(&comp[0],data,N/8);
+		unpack(&comp[0], data, N);
 		cout<<" unpack time = "<<timer.split()<<endl;
 		for(size_t i = 0; i<N; ++i) 
 			assert(data[i] == static_cast<bool>(i & 1));	  
@@ -191,13 +193,13 @@ void testPackUnpackC(size_t N =  2048 * 32 * 2048) {
 int main() {
 	cout<<"pack-unpack test:"<<endl;
 	testPackUnpackC();
-	
+
 	cout<<"cache-cache test:"<<endl;
 
 	cout<<"ignore:"<<testStoreLoad(2048,32,2048)<<endl;
 
 	cout<<"cache-RAM test:"<<endl;
-	
+
 	cout<<"ignore:"<<testStoreLoad()<<endl;
 
 
@@ -206,7 +208,7 @@ int main() {
 	cout<<"ignore:"<<testStoreLoad(2048,32,2048)<<endl;
 
 	cout<<"cache-RAM test:"<<endl;
-	
+
 	cout<<"ignore:"<<testStoreLoad()<<endl;
 
 


### PR DESCRIPTION
pack() and unpack() have bugs due to stepping through both arrays
8-at-a-time: the compressed version of the bool array isn't actually
very compressed - 16 bools packed into 9 bytes.

This isn't noticed because testPackUnpackC() doesn't call pack() and
unpack() with the correct N argument, instead understanding the size
of the arrays by eightfold.
