### PR TITLE
remove duplicates: use blend and avoid type conversions

### DIFF
--- a/2017/04/10/removeduplicates.cpp
+++ b/2017/04/10/removeduplicates.cpp
@@ -301,15 +301,13 @@ uint32_t uniqshuf[] = {
 };
 
 
-static inline int _avx_unique_store(__m256i old, __m256i newval, uint32_t *output) {
-    const __m256i wipelast_mask  = _mm256_set_epi32(0,-1,-1,-1,-1,-1,-1,-1);
-    __m256i wipelast = _mm256_and_si256(newval,wipelast_mask);
-    __m256i oldkeeplast = _mm256_andnot_si256(wipelast_mask, old);
-    __m256i recon  = _mm256_or_si256(wipelast,oldkeeplast);
-    const __m256i movebyone_mask = _mm256_set_epi32(6,5,4,3,2,1,0,7);
-    __m256i vecTmp = _mm256_permutevar8x32_epi32(recon,movebyone_mask);
-    int M = _mm256_movemask_ps(_mm256_cvtepi32_ps(_mm256_cmpeq_epi32(vecTmp, newval)));
-    int numberofnewvalues =  sizeof(__m256i) / sizeof(uint32_t) - _mm_popcnt_u64(M);
+static inline uint32_t _avx_unique_store(__m256i old, __m256i newval, uint32_t *output) {
+    const constexpr uint32_t C = sizeof(__m256i) / sizeof(uint32_t);
+    __m256i recon = _mm256_blend_epi32(old, newval, 0b0111'1111);
+    const __m256i movebyone_mask = _mm256_set_epi32(6,5,4,3,2,1,0,7); // rotate shuffle
+    __m256i vecTmp = _mm256_permutevar8x32_epi32(recon, movebyone_mask);
+    uint32_t M = _mm256_movemask_ps((__m256)_mm256_cmpeq_epi32(vecTmp, newval));
+    uint32_t numberofnewvalues = C - (uint32_t)_mm_popcnt_u32(M);
     __m256i key = _mm256_loadu_si256((const __m256i *)uniqshuf + M);
     __m256i val =_mm256_permutevar8x32_epi32(newval,key);
     _mm256_storeu_si256((__m256i *)output, val);


### PR DESCRIPTION
Nice AVX2 code to remove duplicates. Here's my attempt to improve it a little bit.

The first three instructions can be replaced by a blend between old and
newval. movemask_ps works fine on integers. Avoid conversion to float
by just casting operands. Use uint32_t everywhere to avoid sign
extension instructions.