### PR TITLE
Add "mix" approach

### DIFF
--- a/2018/01/31/randomsample.js
+++ b/2018/01/31/randomsample.js
@@ -19,6 +19,74 @@ function sampleS(m, n) {
    return s;
 }
 
+// Use the "mix" approach, which goes like this:
+//
+// 1) l2 is the smallest value such that 2^l2 >= n
+// 2) for each value x in the sequence 0..m-1 do this:
+// 3) hash x, using a function similar to splitmix64,
+//    which has no collision
+// 4) if the hash is >= n, hash again, until < n
+//
+// This approach doesn't need a (bit-) set,
+// as by design duplicates are avoided.
+// The disadvantage is that it's a custom PRNG.
+//
+// See also:
+// https://stackoverflow.com/questions/664014/what-integer-hash-function-are-good-that-accepts-an-integer-hash-key/12996028#12996028
+// http://xorshift.di.unimi.it/splitmix64.c
+//
+// At step 4, we could also skip the value - but
+// then the sequence can't be generated in parallel.
+
+function mix(m, n) {
+    m = m | 0;
+    n = n | 0;
+    var l2 = nextLog2(n) | 0;
+    var shift = (l2 >> 1) | 0;
+    var mask = ((1 << l2) - 1) | 0;
+    let s = new Int32Array(m);
+	  // var fbs = new FastBitSet();
+    for (let j = 0; (j|0) < m; j = (j+1)|0) {
+        s[j] = next(j, n, shift, mask);
+        // let x = fbs.checkedAdd(s[j]);
+        // assert(x == 1, "Bug in add at " + j);
+    }
+    return s;
+}
+
+function next(x, n, shift, mask) {
+    x = x | 0;
+    n = n | 0;
+    while (true) {
+        x = hash(x, shift, mask);
+        if ((x|0) < n) {
+            return x;
+        }
+    }
+}
+
+function nextLog2(x) {
+    x = x | 0;
+    let n = 1;
+    while ((1 << n) < x) {
+        n++;
+    }
+    return n | 0;
+}
+
+function hash(x, shift, mask) {
+    x = x | 0;
+    shift = shift | 0;
+    mask = mask | 0;
+    x = Math.imul((x >>> shift) ^ x, 0x45d9f3b);
+    x = x & mask;
+    x = Math.imul((x >>> shift) ^ x, 0x45d9f3b);
+    x &= mask;
+    x = x ^ (x >>> shift);
+    x &= mask;
+    return x | 0;
+}
+
 // return m values in the range [0,n)
 // attributed to Floyd
 function sampleF2(m, n) {
@@ -83,6 +151,9 @@ function Bench(m,n) {
   })
   .add('fastsampleS', function() {
     return fastsampleS(m, n);
+  })
+  .add('mix', function() {
+    return mix(m, n);
   })
   // add listeners
   .on('cycle', function(event) {


### PR DESCRIPTION
The "mix" algorithm doesn't need a (bit-) set. 

See my [comment](https://lemire.me/blog/2018/01/31/picking-distinct-numbers-at-random-benchmarking-a-brilliant-algorithm-javascript-edition/#comment-296174).

For me, it is faster than fastsampleS except for the last case ("Sampling 1000000 values in [0,1000000)."), but probably because it's not using floating point, and not because the lack of set. Not using a set has other advantages: it saves memory.
