### PR TITLE
triple and quad stream versions

### DIFF
--- a/2018/10/16/src/main/java/me/lemire/microbenchmarks/algorithms/Utf8Validate.java
+++ b/2018/10/16/src/main/java/me/lemire/microbenchmarks/algorithms/Utf8Validate.java
@@ -184,9 +184,8 @@ static final byte utf8d_transition[] = {
 
   public static boolean isASCIIbranch(byte[] b) {
     int length = b.length;
-    int s = 0;
     for (int i = 0; i < length; i++) {
-      if(b[i] < 0) return false;
+      if (b[i] < 0) return false;
     }
     return true;
   }
@@ -205,6 +204,7 @@ static final byte utf8d_transition[] = {
 	  // check that the byte is a trailing byte of the form 10xxxxxx
 	  return b <= (byte)0xBF; 
   }
+  
   // two stream version of 
   // http://bjoern.hoehrmann.de/utf-8/decoder/dfa/
   public static boolean isUTF8_double(byte[] b) {
@@ -222,6 +222,33 @@ static final byte utf8d_transition[] = {
     }
     return s1 == 0 && s2 == 0;
   }
+  
+  // three stream version of 
+  // http://bjoern.hoehrmann.de/utf-8/decoder/dfa/
+  public static boolean isUTF8_triple(byte[] b) {
+    int length = b.length, chunk = length / 3;
+    int s1 = 0, s2 = 0, s3 = 0;
+    for (int i = 0, j = chunk, k = 2 * chunk; i < chunk; i++, j++, k++) {
+      s1 = utf8d_transition[(s1 + (utf8d_toclass[b[i] & 0xFF])) & 0xFF];
+      s2 = utf8d_transition[(s2 + (utf8d_toclass[b[j] & 0xFF])) & 0xFF];
+      s3 = utf8d_transition[(s3 + (utf8d_toclass[b[k] & 0xFF])) & 0xFF];
+    }
+    return s1 == 0 && s2 == 0 && s3 == 0;
+  }
+  
+ // four stream version of 
+ // http://bjoern.hoehrmann.de/utf-8/decoder/dfa/
+ public static boolean isUTF8_quad(byte[] b) {
+   int length = b.length, chunk = length / 4;
+   int s1 = 0, s2 = 0, s3 = 0, s4 = 0;
+   for (int i = 0, j = chunk, k = 2 * chunk, l = 3 * chunk; i < chunk; i++, j++, k++, l++) {
+     s1 = utf8d_transition[(s1 + (utf8d_toclass[b[i] & 0xFF])) & 0xFF];
+     s2 = utf8d_transition[(s2 + (utf8d_toclass[b[j] & 0xFF])) & 0xFF];
+     s3 = utf8d_transition[(s3 + (utf8d_toclass[b[k] & 0xFF])) & 0xFF];
+     s4 = utf8d_transition[(s4 + (utf8d_toclass[b[l] & 0xFF])) & 0xFF];
+   }
+   return s1 == 0 && s2 == 0 && s3 == 0 && s4 == 0;
+ }
 
   @Benchmark @BenchmarkMode(Mode.AverageTime) 
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -231,8 +258,20 @@ static final byte utf8d_transition[] = {
   
   @Benchmark @BenchmarkMode(Mode.AverageTime) 
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
-  public boolean testFSMDouble_utf8(MyState state) {
+  public boolean testFSM2_utf8(MyState state) {
     return isUTF8_double(state.datautf8);
+  }
+  
+  @Benchmark @BenchmarkMode(Mode.AverageTime) 
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public boolean testFSM3_utf8(MyState state) {
+    return isUTF8_triple(state.datautf8);
+  }
+  
+  @Benchmark @BenchmarkMode(Mode.AverageTime) 
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public boolean testFSM4_utf8(MyState state) {
+    return isUTF8_quad(state.datautf8);
   }
 
   @Benchmark @BenchmarkMode(Mode.AverageTime) 


### PR DESCRIPTION
Here we add 3x and 4x stream versions of the DFA approach. Both are considerably faster than the 2x approach, but between the two which one is faster seems to vary based on N and some other factors I'm not exactly clear on. It seems to be at about the limit, I don't expect a 5x version to speed things up much. The Java code generation is not very optimal: so if you did this in C I think you could do more streams and get a higher speedup, probably faster than 2 cycles per byte. There is a "speed limit" here of 1.5 cycles per byte, no matter how many streams, since each transition needs 3 loads and you can do at most 2 loads per cycle. 

You could perhaps break that speed limit by doing the loads from the string 8 at a time (QWORD) and then shifting and masking to grab a byte at a time. Or you could try to combine the class and transition lookup into a single lookup that takes the raw character value (i.e., get rid of the idea of classes), at the cost of a larger table, or maybe more ALU ops.

Note that these functions don't actually return the right result much of the time: I left out the code to actually align each stream to a code point boundary and also the code to stop on a code point boundary. You could do it like I did in the double case, but it also occurs to me you can do it for free using the existing DFA: start each stream in an special "start" state whose transitions are such that the initial bytes are ignored (i.e., they transition to the normal state graph as soon as they see a starting character), and as the final check just check at the state is not invalid (`s1 != 12`) rather than "valid end of character" (`s0 == 0`). Or something like that. I didn't worry about it because this is a small one-time cost which doesn't affect the main loop, except if it somehow makes the JIT produce worse code.