### PR TITLE
just small tweaks

### DIFF
--- a/2020/01/14/run_with_huge_pages.sh
+++ b/2020/01/14/run_with_huge_pages.sh
@@ -14,15 +14,15 @@ origval=$(sudo cat /sys/kernel/mm/transparent_hugepage/enabled)
 sudo -u $real_user echo $origval
 set -e
 function cleanup {
-  echo "Restauring hugepages to madvise"
+  echo "Restoring hugepages to madvise"
   echo "madvise" > /sys/kernel/mm/transparent_hugepage/enabled
 }
 trap cleanup EXIT
 
-for mode in "always" "never" ; do
+for mode in "always" ; do # "never
   sudo -u $real_user echo "mode: " $mode
   echo $mode > /sys/kernel/mm/transparent_hugepage/enabled
   echo $(sudo cat /sys/kernel/mm/transparent_hugepage/enabled)
-  $@ 
+  $@
 done
 echo "Done."


### PR DESCRIPTION
I feel like I understand from the C++ POV what these performance variations were. There are no weird unexplained artefacts any more. 

It is clear that `hugepages` helps massively with fresh allocations and that is also understandable. 

It is not yet clear to me why we cannot seem to get >50% of the theoretical hardware bandwidth while initialising a fresh allocation (ie `malloc` followed by `memset` or just `calloc`). I get about 6.5GB/s on a machine which theoretically supports 12.8GB/s. More hardware/kernel knowledge would be required to answer that. 

But this is not a C++ issue nor something C++ can do much about (apart from ensuring that your application is deployed with hugepages perms which gets you from 25% to 50% of the theoretical maximum). 

Agreed?