### PR TITLE
Add slightly better SSE2 version and new AVX2 implementation

### DIFF
--- a/2021/11/17/Makefile
+++ b/2021/11/17/Makefile
@@ -1,4 +1,4 @@
 convert : convert.cpp
-	c++ -O3 -Wall -Wextra -std=c++17 -o convert convert.cpp
+	c++ -O3 -Wall -Wextra -std=c++17 -march=native -o convert convert.cpp
 clean:
 	rm -r -f convert

--- a/2021/11/17/Makefile
+++ b/2021/11/17/Makefile
@@ -1,4 +1,4 @@
 convert : convert.cpp
-	c++ -O3 -Wall -Wextra -std=c++17 -march=native -o convert convert.cpp
+	c++ -O3 -Wall -Wextra -std=c++17 -march=skylake -o convert convert.cpp
 clean:
 	rm -r -f convert

--- a/2021/11/17/convert.cpp
+++ b/2021/11/17/convert.cpp
@@ -273,6 +273,83 @@ void to_string_sse2(uint64_t v, char *out) {
   _mm_storeu_si128((__m128i *)out, tmp);
 }
 #endif
+
+#ifdef __SSE4_1__
+void to_string_sse2__pshufb(uint64_t v, char *out) {
+
+  // v is 16-digit number = abcdefghijklmnop
+  const __m128i div_10000 = _mm_set1_epi32(0xd1b71759);
+  const __m128i mul_10000 = _mm_set1_epi32(10000);
+  const int div_10000_shift = 45;
+
+  const __m128i div_100 = _mm_set1_epi16(0x147b);
+  const __m128i mul_100 = _mm_set1_epi16(100);
+  const int div_100_shift = 3;
+
+  const __m128i div_10 = _mm_set1_epi16(0x199a);
+  const __m128i mul_10 = _mm_set1_epi16(10);
+
+  const __m128i ascii0 = _mm_set1_epi8('0');
+
+  // can't be easliy done in SSE
+  const uint32_t a = v / 100000000; // 8-digit number: abcdefgh
+  const uint32_t b = v % 100000000; // 8-digit number: ijklmnop
+
+  //                [ 3 | 2 | 1 | 0 | 3 | 2 | 1 | 0 | 3 | 2 | 1 | 0 | 3 | 2 | 1 | 0 ]
+  // x            = [       0       |      ijklmnop |       0       | abcdefgh  ]
+  __m128i x = _mm_set_epi64x(b, a);
+
+  // x div 10^4   = [       0       |          ijkl |       0       | abcd ]
+  __m128i x_div_10000;
+  x_div_10000 = _mm_mul_epu32(x, div_10000);
+  x_div_10000 = _mm_srli_epi64(x_div_10000, div_10000_shift);
+
+  // x mod 10^4   = [       0       |          mnop |       0       | efgh ]
+  __m128i x_mod_10000;
+  x_mod_10000 = _mm_mul_epu32(x_div_10000, mul_10000);
+  x_mod_10000 = _mm_sub_epi32(x, x_mod_10000);
+
+  // y            = [          mnop |          ijkl |          efgh | abcd ]
+  __m128i y = _mm_or_si128(x_div_10000, _mm_slli_epi64(x_mod_10000, 32));
+
+  // y_div_100    = [   0   |    mn |   0   |    ij |   0   |    ef |   0   | ab
+  // ]
+  __m128i y_div_100;
+  y_div_100 = _mm_mulhi_epu16(y, div_100);
+  y_div_100 = _mm_srli_epi16(y_div_100, div_100_shift);
+
+  // y_mod_100    = [   0   |    op |   0   |    kl |   0   |    gh |   0   | cd    ]
+  __m128i y_mod_100;
+  y_mod_100 = _mm_mullo_epi16(y_div_100, mul_100);
+  y_mod_100 = _mm_sub_epi16(y, y_mod_100);
+
+  // z            = [    mn |    ij |    ef |    ab |    op |    kl |    gh |    cd ]
+  __m128i z = _mm_packus_epi32(y_div_100, y_mod_100);
+
+  // z_div_10     = [ 0 | m | 0 | i | 0 | e | 0 | a | 0 | o | 0 | k | 0 | g | 0 | c ]
+  __m128i z_div_10 = _mm_mulhi_epu16(z, div_10);
+
+  // z_mod_10     = [ 0 | n | 0 | j | 0 | f | 0 | b | 0 | p | 0 | l | 0 | h | 0 | d ]
+  __m128i z_mod_10;
+  z_mod_10 = _mm_mullo_epi16(z_div_10, mul_10);
+  z_mod_10 = _mm_sub_epi16(z, z_mod_10);
+
+  // interleave z_mod_10 and z_div_10 -
+  // tmp          = [ m | i | e | a | o | k | g | c | n | j | f | b | p | l | h | d ]
+  __m128i tmp = _mm_packus_epi16(z_div_10, z_mod_10);
+
+  const __m128i reorder = _mm_set_epi8(
+    15, 7, 11, 3, 14, 6, 10,  2,  13,  5,  9, 1, 12, 4, 8, 0
+  );
+  tmp = _mm_shuffle_epi8(tmp, reorder);
+
+  // convert to ascii
+  tmp = _mm_add_epi8(tmp, ascii0);
+
+  // and save result
+  _mm_storeu_si128((__m128i *)out, tmp);
+}
+#endif
 void to_string_tree_bigtable(uint64_t x, char *out) {
 #include "bigtable.h"
 
@@ -290,6 +367,7 @@ void to_string_tree_bigtable(uint64_t x, char *out) {
   memcpy(out + 12, &bigtable[4 * bottombottom], 4);
 }
 int main() {
+
   std::vector<uint64_t> data;
   for (size_t i = 0; i < 50000; i++) {
     data.push_back(rand() % 10000000000000000);
@@ -354,6 +432,17 @@ int main() {
     return data.size();
   };
 #endif
+
+#ifdef __SSE4_1__
+  auto sse2_approach_v2 = [&data, buf]() -> size_t {
+    char *b = buf;
+    for (auto val : data) {
+      to_string_sse2__pshufb(val, b);
+      b += 16;
+    }
+    return data.size();
+  };
+#endif
   for (size_t i = 0; i < 3; i++) {
     std::cout << "khuong     ";
     std::cout << bench(khuong_approach) << std::endl;
@@ -373,6 +462,12 @@ int main() {
     std::cout << "sse2   ";
     std::cout << bench(sse2_approach) << std::endl;
 #endif
+
+#ifdef __SSE4_1__
+    std::cout << "sse2(2) ";
+    std::cout << bench(sse2_approach_v2) << std::endl;
+#endif
+
     std::cout << std::endl;
   }
   delete[] buf;


### PR DESCRIPTION
The AVX2 version uses... bigtable and the gather instruction. The new version of SSE2 employs `pshufb`. :)

Here are numbers from the Skylake machine

```
$ ./convert 
khuong     7.6338
backlinear 30.6444
linear 24.2012
tree   15.8183
treet  7.62964
treebt 3.3095
sse2   5.3775
sse2(2) 5.07938
avx2    2.46725

khuong     7.62549
backlinear 30.6456
linear 24.1972
tree   15.8215
treet  7.62947
treebt 3.30961
sse2   5.37789
sse2(2) 5.07852
avx2    2.46616

khuong     7.6303
backlinear 30.6491
linear 24.1959
tree   15.8192
treet  7.6307
treebt 3.30958
sse2   5.37734
sse2(2) 5.07795
avx2    2.46578
```