### PR TITLE
Fix binary GCD benchmark

### DIFF
--- a/2013/12/26/gcd.cpp
+++ b/2013/12/26/gcd.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <climits>
 #include <iostream>
 #include <sys/stat.h>
 #include <sys/time.h>
@@ -387,30 +388,30 @@ unsigned int test(unsigned int offset) {
     }
 
   cout << "Ok! " << endl;
-  cout << "We proceed to report timings (smaller values are better)." << endl;
+  cout << "Kops/ms (larger values are better)." << endl;
 
   double q = N * N;
   cout << "basicgcd                    ";
 
   timer.reset();
-  for (unsigned int x = 1; x <= N; ++x)
-    for (unsigned int y = 1; y <= N; ++y)
+  for (unsigned int x = 1 + offset; x <= N + offset; ++x)
+    for (unsigned int y = 1 + offset; y <= N + offset; ++y)
       bogus += basicgcd(x, y);
   ti1 += timer.split();
   cout << q * 0.001 / ti1 << endl;
   cout << "gcdwikipedia2               ";
 
   timer.reset();
-  for (unsigned int x = 1; x <= N; ++x)
-    for (unsigned int y = 1; y <= N; ++y)
+  for (unsigned int x = 1 + offset; x <= N + offset; ++x)
+    for (unsigned int y = 1 + offset; y <= N + offset; ++y)
       bogus += gcdwikipedia2(x, y);
   ti2 += timer.split();
   cout << q * 0.001 / ti2 << endl;
   cout << "gcdwikipedia2fast           ";
 
   timer.reset();
-  for (unsigned int x = 1; x <= N; ++x)
-    for (unsigned int y = 1; y <= N; ++y)
+  for (unsigned int x = 1 + offset; x <= N + offset; ++x)
+    for (unsigned int y = 1 + offset; y <= N + offset; ++y)
       bogus += gcdwikipedia2fast(x, y);
   ti3 += timer.split();
 
@@ -418,55 +419,55 @@ unsigned int test(unsigned int offset) {
   cout << "gcd_recursive               ";
 
   timer.reset();
-  for (unsigned int x = 1; x <= N; ++x)
-    for (unsigned int y = 1; y <= N; ++y)
+  for (unsigned int x = 1 + offset; x <= N + offset; ++x)
+    for (unsigned int y = 1 + offset; y <= N + offset; ++y)
       bogus += gcd_recursive(x, y);
   ti4 += timer.split();
   cout << q * 0.001 / ti4 << endl;
   cout << "gcd_iterative_mod           ";
 
   timer.reset();
-  for (unsigned int x = 1; x <= N; ++x)
-    for (unsigned int y = 1; y <= N; ++y)
+  for (unsigned int x = 1 + offset; x <= N + offset; ++x)
+    for (unsigned int y = 1 + offset; y <= N + offset; ++y)
       bogus += gcd_iterative_mod(x, y);
   ti5 += timer.split();
   cout << q * 0.001 / ti5 << endl;
   cout << "gcdFranke                   ";
 
   timer.reset();
-  for (unsigned int x = 1; x <= N; ++x)
-    for (unsigned int y = 1; y <= N; ++y)
+  for (unsigned int x = 1 + offset; x <= N + offset; ++x)
+    for (unsigned int y = 1 + offset; y <= N + offset; ++y)
       bogus += gcdFranke(x, y);
   ti6 += timer.split();
   cout << q * 0.001 / ti6 << endl;
   cout << "gcdwikipedia3fast           ";
 
   timer.reset();
-  for (unsigned int x = 1; x <= N; ++x)
-    for (unsigned int y = 1; y <= N; ++y)
+  for (unsigned int x = 1 + offset; x <= N + offset; ++x)
+    for (unsigned int y = 1 + offset; y <= N + offset; ++y)
       bogus += gcdwikipedia3fast(x, y);
   ti7 += timer.split();
   cout << q * 0.001 / ti7 << endl;
   cout << "gcdwikipedia4fast           ";
   timer.reset();
-  for (unsigned int x = 1; x <= N; ++x)
-    for (unsigned int y = 1; y <= N; ++y)
+  for (unsigned int x = 1 + offset; x <= N + offset; ++x)
+    for (unsigned int y = 1 + offset; y <= N + offset; ++y)
       bogus += gcdwikipedia4fast(x, y);
   ti8 += timer.split();
   cout << q * 0.001 / ti8 << endl;
   cout << "gcdwikipedia5fast           ";
 
   timer.reset();
-  for (unsigned int x = 1; x <= N; ++x)
-    for (unsigned int y = 1; y <= N; ++y)
+  for (unsigned int x = 1 + offset; x <= N + offset; ++x)
+    for (unsigned int y = 1 + offset; y <= N + offset; ++y)
       bogus += gcdwikipedia5fast(x, y);
   ti9 += timer.split();
   cout << q * 0.001 / ti9 << endl;
   cout << "gcdwikipedia2fastswap       ";
 
   timer.reset();
-  for (unsigned int x = 1; x <= N; ++x)
-    for (unsigned int y = 1; y <= N; ++y)
+  for (unsigned int x = 1 + offset; x <= N + offset; ++x)
+    for (unsigned int y = 1 + offset; y <= N + offset; ++y)
       bogus += gcdwikipedia2fastswap(x, y);
   ti10 += timer.split();
   cout << q * 0.001 / ti10 << endl;
@@ -476,16 +477,16 @@ unsigned int test(unsigned int offset) {
   cout << "gcdwikipedia6fastxchg       ";
 
   timer.reset();
-  for (unsigned int x = 1; x <= N; ++x)
-    for (unsigned int y = 1; y <= N; ++y)
+  for (unsigned int x = 1 + offset; x <= N + offset; ++x)
+    for (unsigned int y = 1 + offset; y <= N + offset; ++y)
       bogus += gcdwikipedia6fastxchg(x, y);
   ti11 += timer.split();
   cout << q * 0.001 / ti11 << endl;
   cout << "gcdwikipedia2fastxchg       ";
 
   timer.reset();
-  for (unsigned int x = 1; x <= N; ++x)
-    for (unsigned int y = 1; y <= N; ++y)
+  for (unsigned int x = 1 + offset; x <= N + offset; ++x)
+    for (unsigned int y = 1 + offset; y <= N + offset; ++y)
       bogus += gcdwikipedia2fastxchg(x, y);
   ti12 += timer.split();
   cout << q * 0.001 / ti12 << endl;
@@ -493,22 +494,22 @@ unsigned int test(unsigned int offset) {
   timer.reset();
   cout << "gcdwikipedia7fast           ";
 
-  for (unsigned int x = 1; x <= N; ++x)
-    for (unsigned int y = 1; y <= N; ++y)
+  for (unsigned int x = 1 + offset; x <= N + offset; ++x)
+    for (unsigned int y = 1 + offset; y <= N + offset; ++y)
       bogus += gcdwikipedia7fast(x, y);
   ti13 += timer.split();
   cout << q * 0.001 / ti13 << endl;
   cout << "gcdwikipedia7fast32         ";
   timer.reset();
-  for (unsigned int x = 1; x <= N; ++x)
-    for (unsigned int y = 1; y <= N; ++y)
+  for (unsigned int x = 1 + offset; x <= N + offset; ++x)
+    for (unsigned int y = 1 + offset; y <= N + offset; ++y)
       bogus += gcdwikipedia7fast32(x, y);
   ti14 += timer.split();
   cout << q * 0.001 / ti14 << endl;
   cout << "gcdwikipedia8Spelvin        ";
   timer.reset();
-  for (unsigned int x = 1; x <= N; ++x)
-    for (unsigned int y = 1; y <= N; ++y)
+  for (unsigned int x = 1 + offset; x <= N + offset; ++x)
+    for (unsigned int y = 1 + offset; y <= N + offset; ++y)
       bogus += gcdwikipedia8Spelvin(x, y);
   ti15 += timer.split();
   cout << q * 0.001 / ti15 << endl;

--- a/2013/12/26/gcd.cpp
+++ b/2013/12/26/gcd.cpp
@@ -310,6 +310,20 @@ unsigned gcd_iterative_mod(unsigned a, unsigned b) {
   return a;
 }
 
+// make sure divsor is smaller to possibly save an iteration
+unsigned gcd_mod_faster(unsigned a, unsigned b) {
+  if (a < b)
+    std::swap(a, b);
+
+  while (b) {
+    unsigned t = b;
+    b = a % b;
+    a = t;
+  }
+
+  return a;
+}
+
 unsigned basicgcd(unsigned x, unsigned y) {
   return (x % y) == 0 ? y : basicgcd(y, x % y);
 }
@@ -361,6 +375,7 @@ unsigned int test(unsigned int offset) {
   int ti13 = 0;
   int ti14 = 0;
   int ti15 = 0;
+  int ti16 = 0;
 
   int bogus = 0;
   cout << "Running tests... ";
@@ -385,6 +400,7 @@ unsigned int test(unsigned int offset) {
       assert(gcdwikipedia2(x, y) == basicgcd(x, y));
       assert(gcdwikipedia2(x, y) == gcdFranke(x, y));
       assert(gcdwikipedia2(x, y) == gcdwikipedia8Spelvin(x, y));
+      assert(gcdwikipedia2(x, y) == gcd_mod_faster(x, y));
     }
 
   cout << "Ok! " << endl;
@@ -513,6 +529,13 @@ unsigned int test(unsigned int offset) {
       bogus += gcdwikipedia8Spelvin(x, y);
   ti15 += timer.split();
   cout << q * 0.001 / ti15 << endl;
+  cout << "gcd_mod_faster              ";
+  timer.reset();
+  for (unsigned int x = 1 + offset; x <= N + offset; ++x)
+    for (unsigned int y = 1 + offset; y <= N + offset; ++y)
+      bogus += gcd_mod_faster(x, y);
+  ti16 += timer.split();
+  cout << q * 0.001 / ti16 << endl;
   return bogus;
 }
 


### PR DESCRIPTION
Benchmarks weren't using the range offset, so they were showing same results for both number ranges.  Results from updated benchmark:

```
gcd between numbers in [1 and 2000]
Running tests... Ok!
Kops/ms (larger values are better).
basicgcd                    50
gcdwikipedia2               20.3046
gcdwikipedia2fast           44.4444
gcd_recursive               50
gcd_iterative_mod           48.1928
gcdFranke                   46.5116
gcdwikipedia3fast           45.4545
gcdwikipedia4fast           61.5385
gcdwikipedia5fast           44.9438
gcdwikipedia2fastswap       43.0108
gcdwikipedia7fast           48.1928
gcdwikipedia7fast32         76.9231
gcdwikipedia8Spelvin        64.5161

gcd between numbers in [1000000001 and 1000002000]
Running tests... Ok!
Kops/ms (larger values are better).
basicgcd                    37.7358
gcdwikipedia2               7.15564
gcdwikipedia2fast           16.4609
gcd_recursive               37.037
gcd_iterative_mod           37.7358
gcdFranke                   16.5289
gcdwikipedia3fast           16.3934
gcdwikipedia4fast           22.3464
gcdwikipedia5fast           16.4609
gcdwikipedia2fastswap       16.3265
gcdwikipedia7fast           18.3486
gcdwikipedia7fast32         31.746
gcdwikipedia8Spelvin        23.3918
```
