### PR TITLE
add DFA tests

### DIFF
--- a/2022/12/29/protocol.cpp
+++ b/2022/12/29/protocol.cpp
@@ -87,13 +87,13 @@ bool no_inline_shiftxor_is_special(std::string_view input) {
 }
 
 #define DFA_STATE_FAIL    0 /* For easier testing. */
-#define DFA_STATE_INIT    1
-#define DFA_STATE_HTTP_1  2
-#define DFA_STATE_HTTP_2  3
-#define DFA_STATE_HTTP_3  4
-#define DFA_STATE_S       5
+#define DFA_STATE_MATCH   1
+#define DFA_STATE_INIT    2
+#define DFA_STATE_HTTP_1  3
+#define DFA_STATE_HTTP_2  4
+#define DFA_STATE_HTTP_3  5
+#define DFA_STATE_S       6
 #define DFA_STATE_HTTP_4  DFA_STATE_S
-#define DFA_STATE_MATCH   6
 #define DFA_STATE_NUL     7
 #define DFA_STATE_HTTPS_1 DFA_STATE_NUL
 #define DFA_STATE_F_1     8
@@ -163,9 +163,9 @@ bool dfa(std::string_view input) {
     {
       state = dfa_states[state][(uint8_t)str[i]];
 
-      if (state == DFA_STATE_FAIL)
+      if (state == DFA_STATE_MATCH || state == DFA_STATE_FAIL)
 	{
-	  return false;
+	  return state == DFA_STATE_MATCH;
 	}
     }
 
@@ -181,9 +181,9 @@ bool no_inline_dfa(std::string_view input) {
     {
       state = dfa_states[state][(uint8_t)str[i]];
 
-      if (state == DFA_STATE_FAIL)
+      if (state == DFA_STATE_MATCH || state == DFA_STATE_FAIL)
 	{
-	  return false;
+	  return state == DFA_STATE_MATCH;
 	}
     }
 

--- a/2022/12/29/protocol.cpp
+++ b/2022/12/29/protocol.cpp
@@ -90,7 +90,8 @@ bool no_inline_shiftxor_is_special(std::string_view input) {
 #define DFA_STATE_HTTP_1  1
 #define DFA_STATE_HTTP_2  2
 #define DFA_STATE_HTTP_3  3
-#define DFA_STATE_HTTP_4  4
+#define DFA_STATE_S       4
+#define DFA_STATE_HTTP_4  DFA_STATE_S
 #define DFA_STATE_MATCH   5
 #define DFA_STATE_NUL     6
 #define DFA_STATE_HTTPS_1 DFA_STATE_NUL
@@ -101,9 +102,9 @@ bool no_inline_shiftxor_is_special(std::string_view input) {
 #define DFA_STATE_FTP_1   10
 #define DFA_STATE_FTP_2   DFA_STATE_NUL
 #define DFA_STATE_WS_1    11
-#define DFA_STATE_WS_2    12
+#define DFA_STATE_WS_2    DFA_STATE_S
 #define DFA_STATE_WSS_1   DFA_STATE_NUL
-#define DFA_STATE_FAIL    13
+#define DFA_STATE_FAIL    12
 
 #define DFA_STATES_COUNT (DFA_STATE_FAIL + 1)
 
@@ -125,9 +126,10 @@ void init_dfa_states()
   memset(dfa_states[DFA_STATE_HTTP_3], DFA_STATE_FAIL, sizeof(*dfa_states));
   dfa_states[DFA_STATE_HTTP_3][(uint8_t)'p'] = DFA_STATE_HTTP_4;
 
-  memset(dfa_states[DFA_STATE_HTTP_4], DFA_STATE_FAIL, sizeof(*dfa_states));
-  dfa_states[DFA_STATE_HTTP_4][(uint8_t)'\0'] = DFA_STATE_MATCH;
-  dfa_states[DFA_STATE_HTTP_4][(uint8_t)'s'] = DFA_STATE_HTTPS_1;
+  /* HTTP_4, WS_2 */
+  memset(dfa_states[DFA_STATE_S], DFA_STATE_FAIL, sizeof(*dfa_states));
+  dfa_states[DFA_STATE_S][(uint8_t)'\0'] = DFA_STATE_MATCH;
+  dfa_states[DFA_STATE_S][(uint8_t)'s'] = DFA_STATE_NUL;
 
   /* HTTPS_1, FILE_3, FTP_2, WSS_1 */
   memset(dfa_states[DFA_STATE_NUL], DFA_STATE_FAIL, sizeof(*dfa_states));
@@ -148,10 +150,6 @@ void init_dfa_states()
 
   memset(dfa_states[DFA_STATE_WS_1], DFA_STATE_FAIL, sizeof(*dfa_states));
   dfa_states[DFA_STATE_WS_1][(uint8_t)'s'] = DFA_STATE_WS_2;
-
-  memset(dfa_states[DFA_STATE_WS_2], DFA_STATE_FAIL, sizeof(*dfa_states));
-  dfa_states[DFA_STATE_WS_2][(uint8_t)'\0'] = DFA_STATE_MATCH;
-  dfa_states[DFA_STATE_WS_2][(uint8_t)'s'] = DFA_STATE_WSS_1;
 
   memset(dfa_states[DFA_STATE_MATCH], DFA_STATE_MATCH, sizeof(*dfa_states));
   memset(dfa_states[DFA_STATE_FAIL], DFA_STATE_FAIL, sizeof(*dfa_states));

--- a/2022/12/29/protocol.cpp
+++ b/2022/12/29/protocol.cpp
@@ -110,8 +110,7 @@ bool no_inline_shiftxor_is_special(std::string_view input) {
 
 static uint8_t dfa_states[DFA_STATES_COUNT][256];
 
-void init_dfa_states()
-{
+void init_dfa_states() {
   memset(dfa_states[DFA_STATE_INIT], DFA_STATE_FAIL, sizeof(*dfa_states));
   dfa_states[DFA_STATE_INIT][(uint8_t)'h'] = DFA_STATE_HTTP_1;
   dfa_states[DFA_STATE_INIT][(uint8_t)'f'] = DFA_STATE_F_1;

--- a/2022/12/29/protocol.cpp
+++ b/2022/12/29/protocol.cpp
@@ -86,27 +86,27 @@ bool no_inline_shiftxor_is_special(std::string_view input) {
          inputu;
 }
 
-#define DFA_STATE_INIT    0
-#define DFA_STATE_HTTP_1  1
-#define DFA_STATE_HTTP_2  2
-#define DFA_STATE_HTTP_3  3
-#define DFA_STATE_S       4
+#define DFA_STATE_FAIL    0 /* For easier testing. */
+#define DFA_STATE_INIT    1
+#define DFA_STATE_HTTP_1  2
+#define DFA_STATE_HTTP_2  3
+#define DFA_STATE_HTTP_3  4
+#define DFA_STATE_S       5
 #define DFA_STATE_HTTP_4  DFA_STATE_S
-#define DFA_STATE_MATCH   5
-#define DFA_STATE_NUL     6
+#define DFA_STATE_MATCH   6
+#define DFA_STATE_NUL     7
 #define DFA_STATE_HTTPS_1 DFA_STATE_NUL
-#define DFA_STATE_F_1     7
-#define DFA_STATE_FILE_1  8
-#define DFA_STATE_FILE_2  9
+#define DFA_STATE_F_1     8
+#define DFA_STATE_FILE_1  9
+#define DFA_STATE_FILE_2  10
 #define DFA_STATE_FILE_3  DFA_STATE_NUL
-#define DFA_STATE_FTP_1   10
+#define DFA_STATE_FTP_1   11
 #define DFA_STATE_FTP_2   DFA_STATE_NUL
-#define DFA_STATE_WS_1    11
+#define DFA_STATE_WS_1    12
 #define DFA_STATE_WS_2    DFA_STATE_S
 #define DFA_STATE_WSS_1   DFA_STATE_NUL
-#define DFA_STATE_FAIL    12
 
-#define DFA_STATES_COUNT (DFA_STATE_FAIL + 1)
+#define DFA_STATES_COUNT  13
 
 static uint8_t dfa_states[DFA_STATES_COUNT][256];
 

--- a/2022/12/29/protocol.cpp
+++ b/2022/12/29/protocol.cpp
@@ -158,15 +158,12 @@ bool dfa(std::string_view input) {
   uint8_t state = DFA_STATE_INIT;
   const char *str = input.data();
 
-  for (size_t i = 0; i < 6; i++)
-    {
-      state = dfa_states[state][(uint8_t)str[i]];
+  for (size_t i = 0; i < 6; i++) {
+    state = dfa_states[state][(uint8_t)str[i]];
 
-      if (state == DFA_STATE_MATCH || state == DFA_STATE_FAIL)
-	{
-	  return state == DFA_STATE_MATCH;
-	}
-    }
+    if (state == DFA_STATE_MATCH || state == DFA_STATE_FAIL)
+      break;
+  }
 
   return state == DFA_STATE_MATCH;
 }
@@ -176,15 +173,12 @@ bool no_inline_dfa(std::string_view input) {
   uint8_t state = DFA_STATE_INIT;
   const char *str = input.data();
 
-  for (size_t i = 0; i < 6; i++)
-    {
-      state = dfa_states[state][(uint8_t)str[i]];
+  for (size_t i = 0; i < 6; i++) {
+    state = dfa_states[state][(uint8_t)str[i]];
 
-      if (state == DFA_STATE_MATCH || state == DFA_STATE_FAIL)
-	{
-	  return state == DFA_STATE_MATCH;
-	}
-    }
+    if (state == DFA_STATE_MATCH || state == DFA_STATE_FAIL)
+      break;
+  }
 
   return state == DFA_STATE_MATCH;
 }
@@ -194,13 +188,12 @@ bool dfa2(std::string_view input) {
   const char *str = input.data();
   size_t j = 0;
 
-  for (size_t i = 0; i < 6; i++)
-    {
-      uint8_t c = (uint8_t)str[j];
-      j += c != 0;
+  for (size_t i = 0; i < 6; i++) {
+    uint8_t c = (uint8_t)str[j];
+    j += c != 0;
 
-      state = dfa_states[state][c];
-    }
+    state = dfa_states[state][c];
+  }
 
   return state == DFA_STATE_MATCH;
 }
@@ -211,13 +204,12 @@ bool no_inline_dfa2(std::string_view input) {
   const char *str = input.data();
   size_t j = 0;
 
-  for (size_t i = 0; i < 6; i++)
-    {
-      uint8_t c = (uint8_t)str[j];
-      j += c != 0;
+  for (size_t i = 0; i < 6; i++) {
+    uint8_t c = (uint8_t)str[j];
+    j += c != 0;
 
-      state = dfa_states[state][c];
-    }
+    state = dfa_states[state][c];
+  }
 
   return state == DFA_STATE_MATCH;
 }
@@ -226,10 +218,9 @@ bool dfa_is_special(std::string_view input) {
   uint8_t state = DFA_STATE_INIT;
   const char *str = input.data();
 
-  for (size_t i = 0; i < 6; i++)
-    {
-      state = dfa_states[state][(uint8_t)str[i]];
-    }
+  for (size_t i = 0; i < 6; i++) {
+    state = dfa_states[state][(uint8_t)str[i]];
+  }
 
   return state == DFA_STATE_MATCH;
 }
@@ -239,10 +230,9 @@ bool no_inline_dfa_is_special(std::string_view input) {
   uint8_t state = DFA_STATE_INIT;
   const char *str = input.data();
 
-  for (size_t i = 0; i < 6; i++)
-    {
-      state = dfa_states[state][(uint8_t)str[i]];
-    }
+  for (size_t i = 0; i < 6; i++) {
+    state = dfa_states[state][(uint8_t)str[i]];
+  }
 
   return state == DFA_STATE_MATCH;
 }


### PR DESCRIPTION
- Specialised DFA which matches NUL-terminated protocol names, reading up to 6 bytes from the buffer.
- dfa terminates when it sees NUL, dfa_is_special always reads six bytes but ignores everything after string termination.
- dfa2 combines both: reads from string six times but doesn't progress beyond first NUL.
- Default simulation size is too small to differentiate these, branch predictors may learn correct branches for the brancy version.