### PR TITLE
ip to string experimentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ perf.data*
 # maven output
 target
 
+# mac garbage
+.DS_Store


### PR DESCRIPTION
Hi Daniel,

Just for fun, I added a variant implementation of Zukowski's version.

On my M2 mac, it gives these results below (see Zukowski by oc line), 
just a little slower than Zukowski's version but using only 1280 bytes
and just a little faster than the "thin table" version.

And I chose to append . character to string instead of prepending it. 

Regards and keep up the very good work with your blog.

```
Running tests.
Functions are ok.
Time per string in ns.
std::to_string (1)  138.552
std::to_string (2)  143.018
blog post (similar) 29.6376
blog post           28.8351
Dimov 1             19.0179
Dimov 2             29.8581
Zukowski            6.86423
Zukowski by oc      6.90387
thin table          7.39256
```