### PR TITLE
add packed lookup table method

### DIFF
--- a/2023/02/01/str.cpp
+++ b/2023/02/01/str.cpp
@@ -352,7 +352,7 @@ std::string ipv71(const uint64_t address) noexcept {
   return output;
 }
 
-std::string ipv81(const uint64_t address) noexcept {
+std::string ipv81(const uint32_t address) noexcept {
   // uses 1025 bytes
   // little-endian version
   constexpr static const char *lookup =

--- a/2023/02/01/str.cpp
+++ b/2023/02/01/str.cpp
@@ -390,18 +390,41 @@ std::string ipv81(const uint32_t address) noexcept {
       "248\356249\356250\356251\356252\356253\356254\356255\356";
   std::string output(4 * 4, '\0');
 
-  char *nextnum = output.data();
+  char *buf = output.data();
 
-  for (int i = 1; i <= 4; i++) {
-    uint8_t by = address >> (32 - 8 * i);
-    uint32_t val = ((uint32_t *)lookup)[by];
-    uint32_t str = val & 0x3fffffff;
+  uint8_t by;
+  uint32_t val, str;
+  size_t digits;
 
-    std::memcpy(nextnum, &str, 4);
-    nextnum += 1 + (val >> 30);
-  }
+  by = address >> 24;
+  val = ((uint32_t *)lookup)[by];
+  str = val & 0x3fffffff;
 
-  output.resize(nextnum - 1 - output.data());
+  std::memcpy(buf, &str, 4);
+  digits = val >> 30;
+
+  by = address >> 16;
+  val = ((uint32_t *)lookup)[by];
+  str = val & 0x3fffffff;
+
+  std::memcpy(buf + digits + 1, &str, 4);
+  digits += val >> 30;
+
+  by = address >> 8;
+  val = ((uint32_t *)lookup)[by];
+  str = val & 0x3fffffff;
+
+  std::memcpy(buf + digits + 2, &str, 4);
+  digits += val >> 30;
+
+  by = address;
+  val = ((uint32_t *)lookup)[by];
+  str = val & 0x3fffffff;
+
+  std::memcpy(buf + digits + 3, &str, 4);
+  digits += val >> 30;
+
+  output.resize(digits + 3);
   return output;
 }
 

--- a/2023/02/01/str.cpp
+++ b/2023/02/01/str.cpp
@@ -392,38 +392,30 @@ std::string ipv81(const uint32_t address) noexcept {
 
   char *buf = output.data();
 
-  uint8_t by;
-  uint32_t val, str;
+  uint32_t val0, val1, val2, val3, str;
   size_t digits;
 
-  by = address >> 24;
-  val = ((uint32_t *)lookup)[by];
-  str = val & 0x3fffffff;
+  val0 = ((uint32_t *)lookup)[(uint8_t)(address >> 24)];
+  val1 = ((uint32_t *)lookup)[(uint8_t)(address >> 16)];
+  val2 = ((uint32_t *)lookup)[(uint8_t)(address >> 8)];
+  val3 = ((uint32_t *)lookup)[(uint8_t)address];
 
+  str = val0 & 0x3fffffff;
   std::memcpy(buf, &str, 4);
-  digits = val >> 30;
 
-  by = address >> 16;
-  val = ((uint32_t *)lookup)[by];
-  str = val & 0x3fffffff;
-
+  str = val1 & 0x3fffffff;
+  digits = val0 >> 30;
   std::memcpy(buf + digits + 1, &str, 4);
-  digits += val >> 30;
 
-  by = address >> 8;
-  val = ((uint32_t *)lookup)[by];
-  str = val & 0x3fffffff;
-
+  str = val2 & 0x3fffffff;
+  digits += val1 >> 30;
   std::memcpy(buf + digits + 2, &str, 4);
-  digits += val >> 30;
 
-  by = address;
-  val = ((uint32_t *)lookup)[by];
-  str = val & 0x3fffffff;
-
+  str = val3 & 0x3fffffff;
+  digits += val2 >> 30;
   std::memcpy(buf + digits + 3, &str, 4);
-  digits += val >> 30;
 
+  digits += val3 >> 30;
   output.resize(digits + 3);
   return output;
 }

--- a/2023/02/01/str.cpp
+++ b/2023/02/01/str.cpp
@@ -388,20 +388,20 @@ std::string ipv81(const uint64_t address) noexcept {
       "232\356233\356234\356235\356236\356237\356238\356239\356"
       "240\356241\356242\356243\356244\356245\356246\356247\356"
       "248\356249\356250\356251\356252\356253\356254\356255\356";
-  std::string output(4 * 3 + 3, '\0');
+  std::string output(4 * 4, '\0');
 
-  char *point = output.data();
+  char *nextnum = output.data();
 
   for (int i = 1; i <= 4; i++) {
     uint8_t by = address >> (32 - 8 * i);
     uint32_t val = ((uint32_t *)lookup)[by];
     uint32_t str = val & 0x3fffffff;
 
-    std::memcpy(point, &str, 4);
-    point += 1 + (val >> 30);
+    std::memcpy(nextnum, &str, 4);
+    nextnum += 1 + (val >> 30);
   }
 
-  output.resize(point - 1 - output.data());
+  output.resize(nextnum - 1 - output.data());
   return output;
 }
 

--- a/2023/02/01/str.cpp
+++ b/2023/02/01/str.cpp
@@ -402,20 +402,20 @@ std::string ipv81(const uint32_t address) noexcept {
 
   str = val0 & 0x3fffffff;
   std::memcpy(buf, &str, 4);
+  digits = val0 >> 30;
 
   str = val1 & 0x3fffffff;
-  digits = val0 >> 30;
   std::memcpy(buf + digits + 1, &str, 4);
+  digits += val1 >> 30;
 
   str = val2 & 0x3fffffff;
-  digits += val1 >> 30;
   std::memcpy(buf + digits + 2, &str, 4);
+  digits += val2 >> 30;
 
   str = val3 & 0x3fffffff;
-  digits += val2 >> 30;
   std::memcpy(buf + digits + 3, &str, 4);
-
   digits += val3 >> 30;
+
   output.resize(digits + 3);
   return output;
 }


### PR DESCRIPTION
Pack integer string size on top bits of the 4-byte string, saving one memory lookup at the cost of couple extra ALU ops.