### PR TITLE
remove an unnecessary string masking operation, saves one AND

### DIFF
--- a/2023/02/01/str.cpp
+++ b/2023/02/01/str.cpp
@@ -436,7 +436,7 @@ std::string ipv81(const uint32_t address) noexcept {
   std::memcpy(buf + digits + 2, &str, 4);
   digits += val2 >> 30;
 
-  str = val3 & 0x3fffffff;
+  str = val3; // no masking needed, last byte never included in output
   std::memcpy(buf + digits + 3, &str, 4);
   digits += val3 >> 30;
 


### PR DESCRIPTION
OK, I finally believe there's nothing more to improve on ipv81, unless it is rewritten in pure assembly. :)