### PR TITLE
Implement sse_type for upper case

### DIFF
--- a/2023/07/13/Makefile
+++ b/2023/07/13/Makefile
@@ -1,16 +1,19 @@
 all: benchmark unit
 
-benchmark: benchmarks/benchmark.cpp sse_type.o sse_table.o
-	c++ -std=c++17 -O3 -Wall -o benchmark benchmarks/benchmark.cpp sse_type.o sse_table.o -Iinclude -Ibenchmarks
+benchmark: benchmarks/benchmark.cpp sse_type.o sse_upper_type.o sse_table.o
+	c++ -std=c++17 -O3 -Wall -o benchmark benchmarks/benchmark.cpp sse_type.o sse_upper_type.o sse_table.o -Iinclude -Ibenchmarks
 
-unit: tests/unit.cpp sse_type.o sse_table.o
-	c++ -std=c++17  -Wall -Wextra -O3 sse_type.o sse_table.o -o unit tests/unit.cpp -Iinclude -fopenmp
+unit: tests/unit.cpp sse_type.o sse_upper_type.o sse_table.o
+	c++ -std=c++17  -Wall -Wextra -O3 sse_type.o sse_upper_type.o sse_table.o -o unit tests/unit.cpp -Iinclude -fopenmp
 
 sse_type.o: src/sse_type.c include/sse_type.h
 	cc -O3 -Wall -Wextra -Wconversion -march=westmere -c src/sse_type.c -Iinclude
+
+sse_upper_type.o: src/sse_upper_type.c include/sse_type.h
+	cc -O3 -Wall -Wextra -Wconversion -march=westmere -c src/sse_upper_type.c -Iinclude
 
 sse_table.o: src/sse_table.c include/sse_type.h
 	cc -O3 -Wall -Wextra -Wconversion -march=westmere -c src/sse_table.c -Iinclude
 
 clean:
-	rm -f benchmark unit sse_type.o sse_table.o
+	rm -f benchmark unit sse_type.o sse_upper_type.o sse_table.o

--- a/2023/07/13/benchmarks/benchmark.cpp
+++ b/2023/07/13/benchmarks/benchmark.cpp
@@ -1868,6 +1868,13 @@ int main() {
                    sum += t;
                  }
                }));
+  pretty_print(N, bytes, "sse_upper_type", bench([&test_data, &sum]() {
+                 for (const std::string &s : test_data) {
+                   uint16_t t;
+                   sse_upper_type(s.data(), &t); // should check error
+                   sum += t;
+                 }
+               }));
   pretty_print(N, bytes, "sse_table", bench([&test_data, &sum]() {
                  for (const std::string &s : test_data) {
                    uint16_t t;

--- a/2023/07/13/include/sse_type.h
+++ b/2023/07/13/include/sse_type.h
@@ -80,6 +80,7 @@
 #define TYPE_DLV (32769u)
 
 bool sse_type(const char *type_string, uint16_t *type);
+bool sse_upper_type(const char *type_string, uint16_t *type);
 bool sse_table(const char *type_string, uint16_t *type);
 size_t sse_length(const char *type_string);
 #endif // SSE_TYPE_H

--- a/2023/07/13/scripts/upper_hash.c
+++ b/2023/07/13/scripts/upper_hash.c
@@ -1,0 +1,161 @@
+/*
+ * hash.c -- Calculate perfect hash for TYPEs and CLASSes
+ *
+ * Copyright (c) 2023, NLnet Labs. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <inttypes.h>
+
+typedef struct tuple tuple_t;
+struct tuple {
+  char name[16];
+  uint16_t code;
+  bool type;
+};
+
+static const tuple_t types_and_classes[] = {
+  // classes
+  { "IN", 1, false },
+  { "CS", 2, false },
+  { "CH", 3, false },
+  { "HS", 4, false },
+  // types
+  { "A", 1, true },
+  { "NS", 2, true },
+  { "MD", 3, true },
+  { "MF", 4, true },
+  { "CNAME", 5, true },
+  { "SOA", 6, true },
+  { "MB", 7, true },
+  { "MG", 8, true },
+  { "MR", 9, true },
+  { "NULL", 10, true },
+  { "WKS", 11, true },
+  { "PTR", 12, true },
+  { "HINFO", 13, true },
+  { "MINFO", 14, true },
+  { "MX", 15, true },
+  { "TXT", 16, true },
+  { "RP", 17, true },
+  { "AFSDB", 18, true },
+  { "X25", 19, true },
+  { "ISDN", 20, true },
+  { "RT", 21, true },
+  { "NSAP", 22, true },
+  { "NSAP-PTR", 23, true },
+  { "SIG", 24, true },
+  { "KEY", 25, true },
+  { "PX", 26, true },
+  { "GPOS", 27, true },
+  { "AAAA", 28, true },
+  { "LOC", 29, true },
+  { "NXT", 30, true },
+  { "SRV", 33, true },
+  { "NAPTR", 35, true },
+  { "KX", 36, true },
+  { "CERT", 37, true },
+  { "A6", 38, true },
+  { "DNAME", 39, true },
+  { "APL", 42, true },
+  { "DS", 43, true },
+  { "SSHFP", 44, true },
+  { "IPSECKEY", 45, true },
+  { "RRSIG", 46, true },
+  { "NSEC", 47, true },
+  { "DNSKEY", 48, true },
+  { "DHCID", 49, true },
+  { "NSEC3", 50, true },
+  { "NSEC3PARAM", 51, true },
+  { "TLSA", 52, true },
+  { "SMIMEA", 53, true },
+  { "HIP", 55, true },
+  { "CDS", 59, true },
+  { "CDNSKEY", 60, true },
+  { "OPENPGPKEY", 61, true },
+  { "CSYNC", 62, true },
+  { "ZONEMD", 63, true },
+  { "SVCB", 64, true },
+  { "HTTPS", 65, true },
+  { "SPF", 99, true },
+  { "NID", 104, true },
+  { "L32", 105, true },
+  { "L64", 106, true },
+  { "LP", 107, true },
+  { "EUI48", 108, true },
+  { "EUI64", 109, true },
+  { "URI", 256, true },
+  { "CAA", 257, true },
+  { "AVC", 258, true },
+  { "DLV", 32769, true }
+};
+
+const uint64_t original_magic = 3523216699ull; // original hash from hash.cpp
+
+static uint8_t hash(uint64_t magic, uint64_t value)
+{
+  uint32_t value32 = ((value >> 32) ^ value);
+  return (value32 * magic) >> 32;
+}
+
+static void print_table(uint64_t magic)
+{
+  struct { uint16_t code; bool type; } keys[256];
+  memset(keys, 0, sizeof(keys));
+  const size_t n = sizeof(types_and_classes)/sizeof(types_and_classes[0]);
+  for (size_t i=0; i < n; i++) {
+    uint64_t value;
+    memcpy(&value, types_and_classes[i].name, 8);
+    uint8_t key = hash(magic, value);
+    keys[key].code = types_and_classes[i].code;
+    keys[key].type = types_and_classes[i].type;
+  }
+
+  printf("static const symbol_t *hash_to_symbol[256] = {\n");
+  for (size_t i=0; i < 256; ) {
+    for (size_t j=i+8; i < j; i++) {
+      uint16_t code = keys[i].code;
+      char macro = !code || keys[i].type ? 'T' : 'C';
+      printf("%c(%u), ", macro, code);
+    }
+    printf("\n");
+  }
+  printf("};\n");
+}
+
+int main(int argc, char *argv[])
+{
+  const size_t n = sizeof(types_and_classes)/sizeof(types_and_classes[0]);
+  for (uint64_t magic = original_magic; magic < UINT64_MAX; magic++) {
+    size_t i;
+    uint16_t keys[256] = { 0 };
+    for (i=0; i < n; i++) {
+      uint64_t value;
+      memcpy(&value, types_and_classes[i].name, 8);
+
+      uint8_t key = hash(magic, value);
+      if (keys[key])
+        break;
+      keys[key] = 1;
+    }
+
+    if (i == n) {
+      printf("i: %zu, magic: %" PRIu64 "\n", i, magic);
+      for (i=0; i < n; i++) {
+        uint64_t value;
+        memcpy(&value, types_and_classes[i].name, 8);
+        uint8_t key = hash(magic, value);
+        printf("TYPE_%s: %" PRIu8 " (%" PRIu16 ")\n", types_and_classes[i].name, key, types_and_classes[i].code);
+      }
+      print_table(magic);
+      return 0;
+    }
+  }
+
+  printf("no magic value\n");
+  return 1;
+}

--- a/2023/07/13/src/sse_upper_type.c
+++ b/2023/07/13/src/sse_upper_type.c
@@ -1,0 +1,415 @@
+#include <stdio.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <x86intrin.h> // update if we need to support Windows.
+
+#include "sse_type.h"
+
+typedef struct symbol symbol_t;
+struct symbol {
+  char name[16];
+  uint16_t code;
+};
+
+static const symbol_t classes[5] = {
+  { { 0 }, 0 }, // reserved
+  { { 'I', 'N', 0 }, CLASS_IN },
+  { { 'C', 'S', 0 }, CLASS_CS },
+  { { 'C', 'H', 0 }, CLASS_CH },
+  { { 'H', 'S', 0 }, CLASS_HS }
+};
+
+static const symbol_t types[260] = {
+  { { 0 }, 0 }, // reserved
+  { { 'A', 0 }, TYPE_A },
+  { { 'N', 'S', 0 }, TYPE_NS },
+  { { 'M', 'D', 0 }, TYPE_MD },
+  { { 'M', 'F', 0 }, TYPE_MF },
+  { { 'C', 'N', 'A', 'M', 'E', 0 }, TYPE_CNAME },
+  { { 'S', 'O', 'A', 0 }, TYPE_SOA },
+  { { 'M', 'B', 0 }, TYPE_MB },
+  { { 'M', 'G', 0 }, TYPE_MG },
+  { { 'M', 'R', 0 }, TYPE_MR },
+  // 10
+  { { 'N', 'U', 'L', 'L', 0 }, TYPE_NULL },
+  { { 'W', 'K', 'S', 0 }, TYPE_WKS },
+  { { 'P', 'T', 'R', 0 }, TYPE_PTR },
+  { { 'H', 'I', 'N', 'F', 'O', 0 }, TYPE_HINFO },
+  { { 'M', 'I', 'N', 'F', 'O', 0 }, TYPE_MINFO },
+  { { 'M', 'X', 0 }, TYPE_MX },
+  { { 'T', 'X', 'T', 0 }, TYPE_TXT },
+  { { 'R', 'P', 0 }, TYPE_RP },
+  { { 'A', 'F', 'S', 'D', 'B', 0 }, TYPE_AFSDB },
+  { { 'X', '2', '5', 0 }, TYPE_X25 },
+  // 20
+  { { 'I', 'S', 'D', 'N', 0 }, TYPE_ISDN },
+  { { 'R', 'T', 0 }, TYPE_RT },
+  { { 'N', 'S', 'A', 'P', 0 }, TYPE_NSAP },
+  { { 'N', 'S', 'A', 'P', '-', 'P', 'T', 'R', 0 }, TYPE_NSAP_PTR },
+  { { 'S', 'I', 'G', 0 }, TYPE_SIG },
+  { { 'K', 'E', 'Y', 0 }, TYPE_KEY },
+  { { 'P', 'X', 0 }, TYPE_PX },
+  { { 'G', 'P', 'O', 'S', 0 }, TYPE_GPOS },
+  { { 'A', 'A', 'A', 'A', 0 }, TYPE_AAAA },
+  { { 'L', 'O', 'C', 0 }, TYPE_LOC },
+  // 30
+  { { 'N', 'X', 'T', 0 }, TYPE_NXT },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 'S', 'R', 'V', 0 }, TYPE_SRV },
+  { { 0 }, 0 },
+  { { 'N', 'A', 'P', 'T', 'R', 0 }, TYPE_NAPTR },
+  { { 'K', 'X', 0 }, TYPE_KX },
+  { { 'C', 'E', 'R', 'T', 0 }, TYPE_CERT },
+  { { 'A', '6', 0 }, TYPE_A6 },
+  { { 'D', 'N', 'A', 'M', 'E', 0 }, TYPE_DNAME },
+  // 40
+  { { '0' }, 0 },
+  { { '0' }, 0 },
+  { { 'A', 'P', 'L', 0 }, TYPE_APL },
+  { { 'D', 'S', 0 }, TYPE_DS },
+  { { 'S', 'S', 'H', 'F', 'P', 0 }, TYPE_SSHFP },
+  { { 'I', 'P', 'S', 'E', 'C', 'K', 'E', 'Y', 0 }, TYPE_IPSECKEY },
+  { { 'R', 'R', 'S', 'I', 'G', 0 }, TYPE_RRSIG },
+  { { 'N', 'S', 'E', 'C', 0 }, TYPE_NSEC },
+  { { 'D', 'N', 'S', 'K', 'E', 'Y', 0 }, TYPE_DNSKEY },
+  { { 'D', 'H', 'C', 'I', 'D', 0 }, TYPE_DHCID },
+  // 50
+  { { 'N', 'S', 'E', 'C', '3', 0 }, TYPE_NSEC3 },
+  { { 'N', 'S', 'E', 'C', '3', 'P', 'A', 'R', 'A', 'M', 0 }, TYPE_NSEC3PARAM },
+  { { 'T', 'L', 'S', 'A', 0 }, TYPE_TLSA },
+  { { 'S', 'M', 'I', 'M', 'E', 'A', 0 }, TYPE_SMIMEA },
+  { { '0' }, 0 },
+  { { 'H', 'I', 'P', 0 }, TYPE_HIP },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 'C', 'D', 'S', 0 }, TYPE_CDS },
+  // 60
+  { { 'C', 'D', 'N', 'S', 'K', 'E', 'Y', 0 }, TYPE_CDNSKEY },
+  { { 'O', 'P', 'E', 'N', 'P', 'G', 'P', 'K', 'E', 'Y', 0 }, TYPE_OPENPGPKEY },
+  { { 'C', 'S', 'Y', 'N', 'C', 0 }, TYPE_CSYNC },
+  { { 'Z', 'O', 'N', 'E', 'M', 'D', 0 }, TYPE_ZONEMD },
+  { { 'S', 'V', 'C', 'B', 0 }, TYPE_SVCB },
+  { { 'H', 'T', 'T', 'P', 'S', 0 }, TYPE_HTTPS },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  // 70
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  // 80
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  // 90
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 'S', 'P', 'F', 0 }, TYPE_SPF },
+  // 100
+  { { '0' }, 0 },
+  { { '0' }, 0 },
+  { { '0' }, 0 },
+  { { '0' }, 0 },
+  { { 'N', 'I', 'D', 0 }, TYPE_NID },
+  { { 'L', '3', '2', 0 }, TYPE_L32 },
+  { { 'L', '6', '4', 0 }, TYPE_L64 },
+  { { 'L', 'P', 0 }, TYPE_LP },
+  { { 'E', 'U', 'I', '4', '8', 0 }, TYPE_EUI48 },
+  { { 'E', 'U', 'I', '6', '4', 0 }, TYPE_EUI64 },
+  // 110
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  // 120
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  // 130
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  // 140
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  // 150
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  // 160
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  // 170
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  // 180
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  // 190
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  // 200
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  // 210
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  // 220
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  // 230
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  // 240
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  // 250
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 0 }, 0 },
+  { { 'U', 'R', 'I', 0 }, TYPE_URI },
+  { { 'C', 'A', 'A', 0 }, TYPE_CAA },
+  { { 'A', 'V', 'C', 0 }, TYPE_AVC },
+  { { 'D', 'L', 'V', 0 }, TYPE_DLV },
+};
+
+
+#define C(n) &classes[n]
+#define T(n) &types[n]
+
+// maps to type code, except for dlv
+static const symbol_t *hash_to_symbol[256] = {
+    T(0),   T(0),   T(0),   T(0),   T(0),  T(44),   T(0),   T(3),
+    T(0),   T(0),   T(0),   T(0),  T(11),   T(0),  T(42),   T(0),
+    T(0),   T(0),   T(0),   T(0),   T(0),  T(62),   T(0),   T(0),
+    T(0),  T(99),  T(25),   T(0),  T(53),   T(0),   T(0),   T(0),
+    T(0),   T(0),   T(0),   T(0),  T(50),   T(0),   T(0),   T(0),
+    T(0),  T(39),   T(0),  T(21),   T(0),   T(5),   T(0),   T(0),
+    T(0),   T(0),   T(0),   T(0),   T(0),   T(1),   T(0),   T(0),
+    C(1),   T(0), T(105),  T(49),   T(0),  T(59),   T(0),   T(29),
+    T(0),  T(20),   T(0),   T(6),   T(0),   T(0),   T(0),   C(3),
+    T(0),  T(63),   T(0),   T(0),   T(0),   C(2),  T(43),  T(37),
+    T(0),   C(4),   T(0),   T(0),  T(45), T(104),   T(2),   T(0),
+   T(23),  T(55),   T(0),  T(24),   T(0),   T(0),   T(0),   T(0),
+    T(0),   T(0),   T(0),   T(7),   T(0),   T(0),   T(0),  T(12),
+    T(0),   T(0),  T(60),   T(0),   T(0),  T(36),  T(10),  T(15),
+    T(0),  T(26),   T(0),   T(0),  T(19),   T(0),   T(0),   T(0),
+    T(0),   T(0),   T(0),  T(65),   T(0),   T(8),   T(0), T(108),
+    T(0),  T(38),   T(0),   T(9),   T(0),   T(0),   T(0),   T(0),
+    T(0),   T(0),   T(0),   T(0),  T(46),   T(0),   T(0),   T(0),
+    T(0),   T(0),   T(0),   T(0),   T(0),   T(0),  T(27),  T(48),
+    T(0),   T(0),   T(0),   T(0),   T(0),   T(0),   T(0),   T(0),
+    T(0),   T(0),   T(0),   T(0),   T(0),   T(0),   T(0),   T(0),
+    T(0),   T(0),  T(28),   T(4),  T(51),   T(0),   T(0),  T(30),
+    T(0), T(106),   T(0),   T(0),  T(16),  T(64),   T(0),   T(0),
+    T(0),   T(0), T(257),   T(0),   T(0),   T(0),   T(0),   T(0),
+  T(256),   T(0),   T(0),   T(0),   T(0),  T(22),   T(0),   T(0),
+    T(0),  T(33),   T(0),  T(61),   T(0),  T(52),   T(0),   T(0),
+  T(259),   T(0),   T(0),   T(0),  T(14),   T(0),   T(0),   T(0),
+   T(13),   T(0),   T(0),   T(0),   T(0),   T(0), T(107),   T(0),
+    T(0),  T(18),   T(0),  T(17),   T(0),   T(0),  T(35),   T(0),
+    T(0),   T(0),   T(0),   T(0),   T(0),   T(0),   T(0),   T(0),
+    T(0),   T(0),   T(0),   T(0), T(258),   T(0),   T(0), T(109),
+    T(0),   T(0),   T(0),   T(0),   T(0),   T(0),  T(47),   T(0)
+};
+
+static int8_t zero_masks[32] = {
+   0,   0,   0,   0,   0,   0,   0,   0,
+   0,   0,   0,   0,   0,   0,   0,   0,
+  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,
+  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1 };
+
+static inline uint8_t hash(uint64_t val)
+{
+  uint32_t val32 = (uint32_t)((val >> 32) ^ val);
+  // magic value generated using upper_hash.c, rerun when adding types
+  return (uint8_t)((val32 * (uint64_t)3523264710) >> 32);
+}
+
+bool sse_upper_type(const char *type_string, uint16_t *type)
+{
+  __m128i input = _mm_loadu_si128((const __m128i *)type_string);
+
+  // RRTYPEs consist of [0-9a-zA-Z-] (unofficially, no other values are in use)
+  // 0x2d        : hyphen : 0b0010_1101
+  // 0x30 - 0x39 :  0 - 9 : 0b0011_0000 - 0b0011_1001
+  // 0x41 - 0x4f :  A - O : 0b0100_0001 - 0b0100_1111
+  // 0x50 - 0x5a :  P - Z : 0b0101_0000 - 0b0101_1010
+  // 0x61 - 0x6f :  a - o : 0b0110_0001 - 0b0110_1111
+  // 0x70 - 0x7a :  p - z : 0b0111_0000 - 0b0111_1010
+  //
+  // Delimiters for strings consisting of a contiguous set of characters
+  // 0x00        :       end-of-file : 0b0000_0000
+  // 0x20        :             space : 0b0010_0000
+  // 0x22        :             quote : 0b0010_0010
+  // 0x28        :  left parenthesis : 0b0010_1000
+  // 0x29        : right parenthesis : 0b0010_1001
+  // 0x09        :               tab : 0b0000_1001
+  // 0x0a        :         line feed : 0b0000_1010
+  // 0x3b        :         semicolon : 0b0011_1011
+  // 0x0d        :   carriage return : 0b0000_1101
+  //
+  // Deltas below do not catch ('.' (0x2e) or '/' (0x2f)), but as those are
+  // not delimiters, it is unimportant.
+  const __m128i deltas = _mm_setr_epi8(
+    -16, -32, -45, 70, -65, 37, -97, 5, 0, 0, 0, 0, 0, 0, 0, 0);
+  const __m128i nibble = _mm_and_si128(_mm_srli_epi32(input, 4), _mm_set1_epi8(0x0f));
+  const __m128i check = _mm_add_epi8(_mm_shuffle_epi8(deltas, nibble), input);
+
+  int mask = (uint16_t)_mm_movemask_epi8(check);
+  uint16_t length = (uint16_t)__builtin_ctz((unsigned int)mask);
+
+  const __m128i upper = _mm_setr_epi8(
+    -1, -1, -1, -1, -1, -1, -33, -33, -1, -1, -1, -1, -1, -1, -1, -1);
+
+  const __m128i zero_mask = _mm_loadu_si128((const __m128i *)(zero_masks + 16 - length));
+  input = _mm_and_si128(input, _mm_shuffle_epi8(upper, nibble));
+  input = _mm_andnot_si128(zero_mask, input);
+
+  // input is now sanitized and upper case
+
+  const uint8_t index = hash((uint64_t)_mm_cvtsi128_si64(input));
+  const symbol_t *symbol = hash_to_symbol[index];
+
+  *type = symbol->code;
+  const __m128i compar = _mm_loadu_si128((const __m128i *)symbol->name);
+  const __m128i xorthem = _mm_xor_si128(compar, input);
+
+  return _mm_test_all_zeros(xorthem, xorthem);
+}

--- a/2023/07/13/tests/unit.cpp
+++ b/2023/07/13/tests/unit.cpp
@@ -59,6 +59,14 @@ bool simple_test() {
       printf("bad type\n");
       return false;
     }
+    if (!sse_upper_type(main.data(), &type)) {
+      printf("expected success\n");
+      return false;
+    }
+    if (type != expected[i]) {
+      printf("bad type\n");
+      return false;
+    }
     if (!sse_table(main.data(), &type)) {
       printf("expected success\n");
       return false;


### PR DESCRIPTION
For simdzone I want to have the name in the descriptor table padded, but as RRTYPEs are normally upper case I wanted to make sure it's not significantly slower. Turns out, it's slightly faster:

```
sse_type                       :   0.97 GB/s  257.3 Ma/s   3.89 ns/d   3.86 GHz  15.01 c/d  41.00 i/d    4.0 c/b  10.87 i/b   2.73 i/c 
sse_upper_type                 :   0.98 GB/s  258.9 Ma/s   3.86 ns/d   3.86 GHz  14.92 c/d  43.00 i/d    4.0 c/b  11.40 i/b   2.88 i/c 
sse_table                      :   0.96 GB/s  254.1 Ma/s   3.93 ns/d   3.86 GHz  15.21 c/d  47.00 i/d    4.0 c/b  12.46 i/b   3.09 i/c 
simple_trie                    :   0.19 GB/s   50.3 Ma/s  19.88 ns/d   3.84 GHz  76.41 c/d  39.00 i/d   20.3 c/b  10.34 i/b   0.51 i/c 
bsearch                        :   0.06 GB/s   15.7 Ma/s  63.51 ns/d   3.80 GHz  241.18 c/d  338.47 i/d   64.0 c/b  89.77 i/b   1.40 i/c 
sse_length                     :   1.45 GB/s  383.2 Ma/s   2.61 ns/d   3.88 GHz  10.12 c/d  19.00 i/d    2.7 c/b   5.04 i/b   1.88 i/c 
finite_match                   :   0.33 GB/s   88.0 Ma/s  11.36 ns/d   3.85 GHz  43.72 c/d  59.25 i/d   11.6 c/b  15.71 i/b   1.36 i/c 
std::lower_bound               :   0.04 GB/s   11.1 Ma/s  90.36 ns/d   3.76 GHz  339.85 c/d  692.92 i/d   90.1 c/b  183.77 i/b   2.04 i/c
```

I've included a simple script to find a magic value for hashing.