### PR TITLE
Add scalar label algorithm for benchmarking

### DIFF
--- a/2023/08/pending/Makefile
+++ b/2023/08/pending/Makefile
@@ -1,12 +1,15 @@
 all:  unit benchmark
-benchmark: benchmarks/benchmark.cpp name_to_dnswire.o 
-	c++ -std=c++17 -O3 -Wall -o benchmark benchmarks/benchmark.cpp name_to_dnswire.o  -Iinclude -Ibenchmarks
+benchmark: benchmarks/benchmark.cpp name_to_dnswire.o scalar_labels.o
+	c++ -std=c++17 -O3 -Wall -o benchmark benchmarks/benchmark.cpp name_to_dnswire.o scalar_labels.o -Iinclude -Ibenchmarks
 
-unit: tests/unit.cpp  name_to_dnswire.o
-	c++ -std=c++17  -Wall -Wextra -O3  name_to_dnswire.o -o unit tests/unit.cpp -Iinclude -fopenmp
+unit: tests/unit.cpp  name_to_dnswire.o scalar_labels.o
+	c++ -std=c++17  -Wall -Wextra -O3 name_to_dnswire.o scalar_labels.o -o unit tests/unit.cpp -Iinclude -fopenmp
 
 name_to_dnswire.o: src/name_to_dnswire.c include/name_to_dnswire.h
 	cc -O3 -Wall -Wextra -Wconversion -march=native -c src/name_to_dnswire.c -Iinclude
 
+scalar_labels.o: src/scalar_labels.c include/name_to_dnswire.h
+	cc -O3 -Wall -Wextra -Wconversion -march=native -c src/scalar_labels.c -Iinclude
+
 clean:
-	rm -f benchmark unit name_to_dnswire.o
+	rm -f benchmark unit name_to_dnswire.o scalar_labels.o

--- a/2023/08/pending/benchmarks/benchmark.cpp
+++ b/2023/08/pending/benchmarks/benchmark.cpp
@@ -96,6 +96,12 @@ int main(int argc, char **argv) {
                    sum += name_to_dnswire_simd(s.data(), output.data());
                  }
                }));
+  pretty_print(inputs.size(), bytes, "name_to_dnswire_scalar_labels",
+               bench([&inputs, &output, &sum]() {
+                 for (const std::string &s : inputs) {
+                   sum += name_to_dnswire_scalar_labels(s.data(), output.data());
+                 }
+               }));
   pretty_print(inputs.size(), bytes, "name_to_dnswire",
                bench([&inputs, &output, &sum]() {
                  for (const std::string &s : inputs) {

--- a/2023/08/pending/include/name_to_dnswire.h
+++ b/2023/08/pending/include/name_to_dnswire.h
@@ -14,4 +14,6 @@ size_t name_to_dnswire_simd(const char *src, uint8_t *dst);
 
 size_t name_to_dnswire(const char *src, uint8_t *dst);
 
+size_t name_to_dnswire_scalar_labels(const char *src, uint8_t *dst);
+
 #endif // NAME_TO_DNSWIRE_H

--- a/2023/08/pending/src/scalar_labels.c
+++ b/2023/08/pending/src/scalar_labels.c
@@ -1,0 +1,88 @@
+// simplified version of text-to-wire from simdzone
+#include "name_to_dnswire.h"
+
+#include <stdint.h>
+#include <x86intrin.h> // update if we need to support Windows.
+
+typedef struct name_block name_block_t;
+struct name_block {
+  __m128i input;
+  uint64_t delimiters;
+  uint64_t labels;
+};
+
+__attribute__((always_inline))
+static inline void copy_name_block(
+  name_block_t *block, const char *text, uint8_t *wire)
+{
+  // Delimiters for strings consisting of a contiguous set of characters
+  // 0x00        :       end-of-file : 0b0000_0000
+  // 0x20        :             space : 0b0010_0000
+  // 0x22        :             quote : 0b0010_0010
+  // 0x28        :  left parenthesis : 0b0010_1000
+  // 0x29        : right parenthesis : 0b0010_1001
+  // 0x09        :               tab : 0b0000_1001
+  // 0x0a        :         line feed : 0b0000_1010
+  // 0x3b        :         semicolon : 0b0011_1011
+  // 0x0d        :   carriage return : 0b0000_1101
+  const __m128i delimiters = _mm_setr_epi8(
+    0x00, 0x00, 0x22, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x28, 0x09, 0x0a, 0x3b, 0x00, 0x0d, 0x00, 0x00);
+
+  const __m128i mask = _mm_setr_epi8(
+    -33, -1, -1, -1, -1, -1, -1, -1, -1, -33, -1, -1, -1, -1, -1, -1);
+
+  block->input = _mm_loadu_si128((const __m128i *)text);
+
+  // setup delimiter pattern for comparison
+  __m128i pattern = _mm_shuffle_epi8(delimiters, block->input);
+  // clear 5th bit (match 0x20 with 0x00, match 0x29 using 0x09)
+  const __m128i masked = _mm_and_si128(block->input, _mm_shuffle_epi8(mask, block->input));
+  const __m128i matched = _mm_cmpeq_epi8(masked, pattern);
+  const __m128i labels = _mm_cmpeq_epi8(block->input, _mm_set1_epi8('.'));
+
+  _mm_storeu_si128((__m128i *)wire, block->input);
+
+  block->delimiters = (uint16_t)_mm_movemask_epi8(matched);
+  block->labels = (uint16_t)_mm_movemask_epi8(labels);
+}
+
+size_t name_to_dnswire_scalar_labels(const char *src, uint8_t *dst)
+{
+  name_block_t block = { 0 };
+  const char *text = src;
+  uint8_t *label = dst, *wire = dst + 1;
+
+  while (1) {
+    copy_name_block(&block, text, wire);
+
+    // backslash check stripped for comparison with @lemire's algorithm
+    block.labels &= block.delimiters - 1;
+    const size_t size = __builtin_ctzll(block.delimiters | (1llu << 16));
+    text += size;
+    wire += size;
+
+    if (block.labels) {
+      uint64_t count = 0, last = 0;
+      const uint64_t labels = __builtin_popcountll(block.labels);
+      for (uint64_t i = 0; i < labels; i++) {
+        const uint64_t length = __builtin_ctzll(block.labels) - last;
+        block.labels &= block.labels - 1;
+        *label += (uint8_t)length;
+        label += *label + 1;
+        *label = 0;
+        last += length + 1;
+      }
+      *label += (wire - label) - 1;
+    } else {
+      *label += (uint8_t)size;
+      if (*label > 63)
+        return 0;
+    }
+
+    if (block.delimiters)
+      break;
+  }
+
+  return wire - dst;
+}

--- a/2023/08/pending/tests/unit.cpp
+++ b/2023/08/pending/tests/unit.cpp
@@ -40,6 +40,13 @@ bool simple_test() {
     printf("%02x ", out[i]);
   }
   printf("\n");
+  read = name_to_dnswire(basic.c_str(), out.data());
+  read += 2;
+  printf("name_to_dnswire_scalar_labels output:\n");
+  for (size_t i = 0; i < read; i++) {
+    printf("%02x ", out[i]);
+  }
+  printf("\n");
 
   printf("\nSUCCESS\n");
   return true;
@@ -134,6 +141,14 @@ bool random_test() {
     size_t read2 = name_to_dnswire_simd(basic.c_str(), out2.data());
     out2.resize(read2);
     if (out1 != out2) {
+      std::cout << basic << std::endl;
+      abort();
+    }
+    std::vector<uint8_t> out3;
+    out3.resize(basic.size() + 32);
+    size_t read3 = name_to_dnswire_scalar_labels(basic.c_str(), out3.data());
+    out3.resize(read3);
+    if (out1 != out3) {
       std::cout << basic << std::endl;
       abort();
     }


### PR DESCRIPTION
There's still some warnings in there that I'll fix asap, but preliminary results show `name_to_dnswire_simd` is the faster algorithm.

```
./benchmark top-1m.csv
loaded 1000000 names
average length 25.656 bytes/name
name_to_dnswire_simd           :   2.09 GB/s   81.4 Ma/s  12.29 ns/d   3.88 GHz  47.75 c/d  112.92 i/d    1.9 c/b   4.40 i/b   2.36 i/c 
name_to_dnswire_scalar_labels  :   1.37 GB/s   53.3 Ma/s  18.76 ns/d   3.88 GHz  72.84 c/d  119.15 i/d    2.8 c/b   4.64 i/b   1.64 i/c 
name_to_dnswire                :   0.64 GB/s   24.9 Ma/s  40.20 ns/d   3.88 GHz  156.06 c/d  258.38 i/d    6.1 c/b  10.07 i/b   1.66 i/c
```