### PR TITLE
Alternative version of name_to_dnswire_idx_avx

### DIFF
--- a/2023/08/09/benchmarks/benchmark.cpp
+++ b/2023/08/09/benchmarks/benchmark.cpp
@@ -108,6 +108,12 @@ int main(int argc, char **argv) {
                    sum += name_to_dnswire_idx_avx(s.data(), output.data());
                  }
                }));
+  pretty_print(inputs.size(), bytes, "name_to_dnswire_loop",
+               bench([&inputs, &output, &sum]() {
+                 for (const std::string &s : inputs) {
+                   sum += name_to_dnswire_loop(s.data(), output.data());
+                 }
+               }));
   pretty_print(inputs.size(), bytes, "name_to_dnswire_avx",
                bench([&inputs, &output, &sum]() {
                  for (const std::string &s : inputs) {

--- a/2023/08/09/include/name_to_dnswire.h
+++ b/2023/08/09/include/name_to_dnswire.h
@@ -12,6 +12,7 @@
 // Returns the number of bytes consumed.
 size_t name_to_dnswire_simd(const char *src, uint8_t *dst);
 size_t name_to_dnswire_avx(const char *src, uint8_t *dst);
+size_t name_to_dnswire_loop(const char *src, uint8_t *dst);
 size_t name_to_dnswire_idx_avx(const char *src, uint8_t *dst);
 #ifdef __AVX512F__
 size_t name_to_dnswire_idx_avx512(const char *src, uint8_t *dst);

--- a/2023/08/09/src/name_to_dnswire.c
+++ b/2023/08/09/src/name_to_dnswire.c
@@ -667,10 +667,10 @@ size_t name_to_dnswire_loop(const char *src, uint8_t *dst)
     while (dots) {
       base = count;
       count = _tzcnt_u64(dots);
-      const uint64_t x = count - base;
+      const uint64_t diff = count - base;
       dots &= dots - 1;
-      octets[label] = (uint8_t)(x - 1);
-      label += x;
+      octets[label] = (uint8_t)(diff - 1);
+      label += diff;
     }
 
     octets[label] = (uint8_t)((length - count) - 1);
@@ -679,7 +679,7 @@ size_t name_to_dnswire_loop(const char *src, uint8_t *dst)
   }
 
   if (likely(delimiter))
-    return length;
+    return length + 1;
 
   // labels in domain names are limited to 63 octets. track length octets
   // (dots) in 64-bit wide bitmap. shift by length of block last copied to
@@ -714,10 +714,10 @@ size_t name_to_dnswire_loop(const char *src, uint8_t *dst)
       while (dots) {
         base = count;
         count = _tzcnt_u64(dots);
-        const uint64_t x = count - base;
+        const uint64_t diff = count - base;
         dots &= dots - 1;
-        octets[label] = (uint8_t)(x - 1);
-        label += x;
+        octets[label] = (uint8_t)(diff - 1);
+        label += diff;
       }
 
       octets[label] = (uint8_t)((length - count) - 1);


### PR DESCRIPTION
**work-in-progress**

Domain names, at least in zone data, may contain escape sequences. For that reason, reading in fixed blocks poses a problem. This attempt leverages the fact that labels cannot exceed 63 octets by checking for overlong labels using a bitmap.

```
$ ./benchmark top-1m.csv
loaded 1000000 names
average length 25.5398 bytes/name
name_to_dnswire_idx_avx is simdjson-like
name_to_dnswire_avx is Prefix-Minimum
name_to_dnswire is conventional

name_to_dnswire_idx_avx512     :   1.75 GB/s   68.5 Ma/s  14.60 ns/d   3.78 GHz  55.15 c/d  79.48 i/d    2.2 c/b   3.11 i/b   1.44 i/c 
name_to_dnswire_idx_avx        :   1.83 GB/s   71.6 Ma/s  13.97 ns/d   3.88 GHz  54.16 c/d  87.08 i/d    2.1 c/b   3.41 i/b   1.61 i/c 
name_to_dnswire_loop           :   1.55 GB/s   60.8 Ma/s  16.45 ns/d   3.87 GHz  63.74 c/d  99.43 i/d    2.5 c/b   3.89 i/b   1.56 i/c 
name_to_dnswire_avx            :   2.22 GB/s   87.0 Ma/s  11.50 ns/d   3.88 GHz  44.56 c/d  80.14 i/d    1.7 c/b   3.14 i/b   1.80 i/c 
name_to_dnswire_simd           :   2.06 GB/s   80.6 Ma/s  12.41 ns/d   3.87 GHz  48.08 c/d  113.62 i/d    1.9 c/b   4.45 i/b   2.36 i/c 
name_to_dnswire_scalar_labels  :   1.34 GB/s   52.4 Ma/s  19.08 ns/d   3.87 GHz  73.86 c/d  119.43 i/d    2.9 c/b   4.68 i/b   1.62 i/c 
name_to_dnswire                :   0.61 GB/s   23.7 Ma/s  42.17 ns/d   3.84 GHz  162.02 c/d  258.27 i/d    6.3 c/b  10.11 i/b   1.59 i/c
```

Somewhat slower than `name_to_dnswire_idx_avx`, but maybe we can base future work on this?