### PR TITLE
Add faster identifier parsing routines

### DIFF
--- a/2023/09/03/benchmarks/benchmark.cpp
+++ b/2023/09/03/benchmarks/benchmark.cpp
@@ -56,6 +56,24 @@ int main(int argc, char **argv) {
                        exit(1);
                    }
                }));
+  pretty_print(input_data.size(), identifiers, "count_identifiers_neon_strager",
+               bench([&input_data, &sum, &identifiers]() {
+                   size_t r = count_identifiers_neon_strager(input_data.data(), input_data.size());
+                   sum += r;
+                   if(r != identifiers) {
+                       printf("FAIL %zu %zu\n", r, identifiers);
+                       exit(1);
+                   }
+               }));
+  pretty_print(input_data.size(), identifiers, "count_identifiers_neon_strager_ranges",
+               bench([&input_data, &sum, &identifiers]() {
+                   size_t r = count_identifiers_neon_strager_ranges(input_data.data(), input_data.size());
+                   sum += r;
+                   if(r != identifiers) {
+                       printf("FAIL %zu %zu\n", r, identifiers);
+                       exit(1);
+                   }
+               }));
   pretty_print(input_data.size(), identifiers, "count_identifiers",
                bench([&input_data, &sum, &identifiers]() {
                    size_t r = count_identifiers(input_data.data(), input_data.size());
@@ -65,4 +83,4 @@ int main(int argc, char **argv) {
                        exit(1);
                    }
                }));
-  }
+}

--- a/2023/09/03/include/identifiers.h
+++ b/2023/09/03/include/identifiers.h
@@ -7,5 +7,7 @@
 /* Identifiers can start with an ascii letter or _, and they can contain letters, _ or digits. */
 size_t count_identifiers(const char *source, size_t size);
 size_t count_identifiers_neon(const char *source, size_t size);
+size_t count_identifiers_neon_strager(const char *source, size_t size);
+size_t count_identifiers_neon_strager_ranges(const char *source, size_t size);
 
 #endif // NAME_TO_DNSWIRE_H


### PR DESCRIPTION
Implement two improvements to count_identifiers_neon:

* count_identifiers_neon_strager: 5-6% speedup over count_identifiers_neon. Use a faster method of generating the bitmasks. This bitmask generated is 32-bit instead of 16-bit, consuming two bit per uint8x16_t element instead of one bit per, necessitating some changes to the main loop.

* count_identifiers_neon_strager_ranges: 7-8% speedup over count_identifiers_neon. Optimized bitmask as above, and also use ranges ('a' <= c <= 'z', for example) instead of tables for classification.

Performance results on my Apple M1 with Apple clang version 14.0.0 (clang-1400.0.29.202) (fastest of 3):

count_identifiers_neon                   :   0.47 GB/s  8984.6 Ma/s   0.11 ns/d
count_identifiers_neon_strager           :   0.50 GB/s  9497.3 Ma/s   0.11 ns/d
count_identifiers_neon_strager_ranges    :   0.51 GB/s  9662.1 Ma/s   0.10 ns/d
count_identifiers                        :   0.04 GB/s   824.1 Ma/s   1.21 ns/d