### PR TITLE
Update .NET benchmark code - simplify and improve performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ target
 
 # mac garbage
 .DS_Store
+
+# dotnet artifacts
+bin/
+obj/
+BenchmarkDotNet.Artifacts/

--- a/2024/07/05/README.md
+++ b/2024/07/05/README.md
@@ -1,4 +1,4 @@
-You need dotnet 8 or better on an ARM system.
+You need dotnet >=9 (preview or release) and an ARM system.
 
 ## Running Benchmarks
 

--- a/2024/07/05/SimdHTML.sln
+++ b/2024/07/05/SimdHTML.sln
@@ -3,11 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "benchmark", "benchmark\benchmark.csproj", "{6C7744C5-AF3E-446A-8475-B03001989AB8}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimdHTML", "src\SimdHTML.csproj", "{3806E828-9AFF-47C3-854F-C8049DC2091E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimdHTML", "src\SimdHTML.csproj", "{14D65B6D-24CD-4616-AAEF-ADBEB5E390A0}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "tests", "test\tests.csproj", "{BDAFE9A2-0CC2-4F72-919F-7D9A8D185EBE}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "benchmark", "benchmark\benchmark.csproj", "{A0993DE7-14A4-4206-B5D3-6FCD0B6D46C3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -18,17 +16,13 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{6C7744C5-AF3E-446A-8475-A03001989AB8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6C7744C5-AF3E-446A-8475-A03001989AB8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6C7744C5-AF3E-446A-8475-A03001989AB8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6C7744C5-AF3E-446A-8475-A03001989AB8}.Release|Any CPU.Build.0 = Release|Any CPU
-		{14D65B6D-24CD-4616-AAEF-BDBEB5E390A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{14D65B6D-24CD-4616-AAEF-BDBEB5E390A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{14D65B6D-24CD-4616-AAEF-BDBEB5E390A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{14D65B6D-24CD-4616-AAEF-BDBEB5E390A0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{BDAFE9A2-0CC2-4F72-919F-5D9A8D185EBE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BDAFE9A2-0CC2-4F72-919F-5D9A8D185EBE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BDAFE9A2-0CC2-4F72-919F-5D9A8D185EBE}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BDAFE9A2-0CC2-4F72-919F-5D9A8D185EBE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3806E828-9AFF-47C3-854F-C8049DC2091E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3806E828-9AFF-47C3-854F-C8049DC2091E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3806E828-9AFF-47C3-854F-C8049DC2091E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3806E828-9AFF-47C3-854F-C8049DC2091E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A0993DE7-14A4-4206-B5D3-6FCD0B6D46C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A0993DE7-14A4-4206-B5D3-6FCD0B6D46C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A0993DE7-14A4-4206-B5D3-6FCD0B6D46C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A0993DE7-14A4-4206-B5D3-6FCD0B6D46C3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/2024/07/05/benchmark/Benchmark.cs
+++ b/2024/07/05/benchmark/Benchmark.cs
@@ -26,29 +26,6 @@ public class RealDataBenchmark
     public string? FileName;
     byte[] allLinesUtf8 = [];
 
-    public unsafe delegate void HTMLScanFunction(ref byte* pUtf8, byte* end);
-
-    private void RunHTMLScanBenchmark(byte[] data, HTMLScanFunction HTMLScanFunction)
-    {
-        unsafe
-        {
-            fixed (byte* pUtf8 = data)
-            {
-                byte* start = pUtf8;
-                byte* end = pUtf8 + data.Length;
-                while (start != end)
-                {
-                    HTMLScanFunction(ref start, end);
-                    if (start == end)
-                    {
-                        break;
-                    }
-                    start++;
-                }
-            }
-        }
-    }
-
     [GlobalSetup]
     public void Setup()
     {
@@ -69,7 +46,7 @@ public class RealDataBenchmark
                     byte* end = pUtf8 + allLinesUtf8.Length;
                     while (start != end)
                     {
-                        SimdHTML.FastScan.SIMDAdvanceString(ref start, end);
+                        FastScan.SIMDAdvanceString(ref start, end);
                         if (start == end)
                         {
                             break;
@@ -96,7 +73,7 @@ public class RealDataBenchmark
                 {
                     byte* start = pUtf8;
                     byte* end = pUtf8 + allLinesUtf8.Length;
-                    SimdHTML.NeonMatch match = new SimdHTML.NeonMatch(start, end);
+                    var match = new NeonMatch(start, end);
                     while (match.Advance())
                     {
                         count += *match.Get();
@@ -144,7 +121,7 @@ public class RealDataBenchmark
                     byte* end = pUtf8 + allLinesUtf8.Length;
                     while (start != end)
                     {
-                        SimdHTML.FastScan.NaiveAdvanceString(ref start, end);
+                        FastScan.NaiveAdvanceString(ref start, end);
                         if (start == end)
                         {
                             break;

--- a/2024/07/05/benchmark/Benchmark.cs
+++ b/2024/07/05/benchmark/Benchmark.cs
@@ -1,332 +1,184 @@
-﻿using System;
-using SimdHTML;
+﻿using SimdHTML;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Reports;
-using BenchmarkDotNet.Filters;
-using BenchmarkDotNet.Jobs;
-using System.Text;
-using System.Runtime;
-using System.Runtime.InteropServices;
+using Utils.Benchmark;
 using System.Buffers;
-using System.IO;
-using System.Collections.Generic;
-using System.Linq;
-using BenchmarkDotNet.Columns;
-using System.Runtime.Intrinsics;
-using System.Runtime.Intrinsics.X86;
 using System.Runtime.Intrinsics.Arm;
-using System.Runtime.CompilerServices;
-using Perfolizer.Horology;
 
-
-namespace SimdHTMLBenchmarks
+if (args.Length == 0)
 {
+    args = ["--filter", "*"];
+}
 
+BenchmarkSwitcher
+    .FromAssembly(typeof(Program).Assembly)
+    .Run(args, DefaultConfig.Instance.WithSummaryStyle(SummaryStyle.Default.WithMaxParameterColumnWidth(100)));
 
-    public class Speed : IColumn
+[SpeedColumn]
+[SimpleJob(launchCount: 1, warmupCount: 3, iterationCount: 6)]
+public class RealDataBenchmark
+{
+    // Parameters and variables for real data
+    [Params(@"data/data.html")]
+#pragma warning disable CA1051
+    public string? FileName;
+    byte[] allLinesUtf8 = [];
+
+    public unsafe delegate void HTMLScanFunction(ref byte* pUtf8, byte* end);
+
+    private void RunHTMLScanBenchmark(byte[] data, HTMLScanFunction HTMLScanFunction)
     {
-        public string GetValue(Summary summary, BenchmarkCase benchmarkCase)
+        unsafe
         {
-            if (summary is null || benchmarkCase is null || benchmarkCase.Parameters is null)
+            fixed (byte* pUtf8 = data)
             {
-                return "N/A";
+                byte* start = pUtf8;
+                byte* end = pUtf8 + data.Length;
+                while (start != end)
+                {
+                    HTMLScanFunction(ref start, end);
+                    if (start == end)
+                    {
+                        break;
+                    }
+                    start++;
+                }
             }
-            var ourReport = summary.Reports.First(x => x.BenchmarkCase.Equals(benchmarkCase));
-            var fileName = (string)benchmarkCase.Parameters["FileName"];
-            if (ourReport is null || ourReport.ResultStatistics is null)
-            {
-                return "N/A";
-            }
-            long length = new System.IO.FileInfo(fileName).Length;
-            var mean = ourReport.ResultStatistics.Mean;
-            return $"{(length / ourReport.ResultStatistics.Mean):#####.00}";
         }
-
-        public string GetValue(Summary summary, BenchmarkCase benchmarkCase, SummaryStyle style) => GetValue(summary, benchmarkCase);
-        public bool IsDefault(Summary summary, BenchmarkCase benchmarkCase) => false;
-        public bool IsAvailable(Summary summary) => true;
-
-        public string Id { get; } = nameof(Speed);
-        public string ColumnName { get; } = "Speed (GB/s)";
-        public bool AlwaysShow { get; } = true;
-        public ColumnCategory Category { get; } = ColumnCategory.Custom;
-        public int PriorityInCategory { get; }
-        public bool IsNumeric { get; }
-        public UnitType UnitType { get; } = UnitType.Dimensionless;
-        public string Legend { get; } = "The speed in gigabytes per second";
     }
 
-
-    [SimpleJob(launchCount: 1, warmupCount: 3, iterationCount: 3)]
-    [Config(typeof(Config))]
-    public class RealDataBenchmark
+    [GlobalSetup]
+    public void Setup()
     {
-        // We only informs the user once about the SIMD support of the system.
-        private static bool printed;
-#pragma warning disable CA1812
-        private sealed class Config : ManualConfig
-        {
-            public Config()
-            {
-                AddColumn(new Speed());
+        allLinesUtf8 = FileName == null ? allLinesUtf8 : File.ReadAllBytes(FileName);
+    }
 
-                if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
-                {
-                    if (!printed)
-                    {
-#pragma warning disable CA1303
-                        Console.WriteLine("ARM64 system detected.");
-                        printed = true;
-                    }
-                }
-                else if (RuntimeInformation.ProcessArchitecture == Architecture.X64)
-                {
-                    if (Vector512.IsHardwareAccelerated && System.Runtime.Intrinsics.X86.Avx512Vbmi.IsSupported)
-                    {
-                        if (!printed)
-                        {
-#pragma warning disable CA1303
-                            Console.WriteLine("X64 system detected (Intel, AMD,...) with AVX-512 support.");
-                            printed = true;
-                        }
-                    }
-                    else if (Avx2.IsSupported)
-                    {
-                        if (!printed)
-                        {
-#pragma warning disable CA1303
-                            Console.WriteLine("X64 system detected (Intel, AMD,...) with AVX2 support.");
-                            printed = true;
-                        }
-                    }
-                    else if (Ssse3.IsSupported)
-                    {
-                        if (!printed)
-                        {
-#pragma warning disable CA1303
-                            Console.WriteLine("X64 system detected (Intel, AMD,...) with Sse4.2 support.");
-                            printed = true;
-                        }
-                    }
-                    else
-                    {
-                        if (!printed)
-                        {
-#pragma warning disable CA1303
-                            Console.WriteLine("X64 system detected (Intel, AMD,...) without relevant SIMD support.");
-                            printed = true;
-                        }
-                    }
-                }
-                AddFilter(new AnyCategoriesFilter(["default"]));
-
-            }
-        }
-        // Parameters and variables for real data
-        [Params(@"data/data.html")]
-#pragma warning disable CA1051
-        public string? FileName;
-        private byte[] allLinesUtf8 = Array.Empty<byte>();
-
-
-        public unsafe delegate void HTMLScanFunction(ref byte* pUtf8, byte* end);
-
-        private void RunHTMLScanBenchmark(byte[] data, HTMLScanFunction HTMLScanFunction)
+    [Benchmark]
+    public unsafe int SIMDHTMLScan()
+    {
+        int count = 0;
+        if (allLinesUtf8 != null)
         {
             unsafe
             {
-                fixed (byte* pUtf8 = data)
+                fixed (byte* pUtf8 = allLinesUtf8)
                 {
                     byte* start = pUtf8;
-                    byte* end = pUtf8 + data.Length;
+                    byte* end = pUtf8 + allLinesUtf8.Length;
                     while (start != end)
                     {
-                        HTMLScanFunction(ref start, end);
+                        SimdHTML.FastScan.SIMDAdvanceString(ref start, end);
                         if (start == end)
                         {
                             break;
                         }
+                        count += *start;
                         start++;
                     }
                 }
             }
         }
-
-        [GlobalSetup]
-        public void Setup()
-        {
-            allLinesUtf8 = FileName == null ? allLinesUtf8 : File.ReadAllBytes(FileName);
-        }
-
-
-        [Benchmark]
-        [BenchmarkCategory("default")]
-
-        public unsafe int SIMDHTMLScan()
-        {
-            int count = 0;
-            if (allLinesUtf8 != null)
-            {
-                unsafe
-                {
-                    fixed (byte* pUtf8 = allLinesUtf8)
-                    {
-                        byte* start = pUtf8;
-                        byte* end = pUtf8 + allLinesUtf8.Length;
-                        while (start != end)
-                        {
-                            SimdHTML.FastScan.SIMDAdvanceString(ref start, end);
-                            if (start == end)
-                            {
-                                break;
-                            }
-                            count += *start;
-                            start++;
-                        }
-                    }
-                }
-            }
-            return count;
-        }
-
-
-
-        [Benchmark]
-        [BenchmarkCategory("default")]
-        public unsafe int NEONHTMLScan()
-        {
-            int count = 0;
-            if (allLinesUtf8 != null && AdvSimd.Arm64.IsSupported)
-            {
-
-                unsafe
-                {
-                    fixed (byte* pUtf8 = allLinesUtf8)
-                    {
-                        byte* start = pUtf8;
-                        byte* end = pUtf8 + allLinesUtf8.Length;
-                        SimdHTML.NeonMatch match = new SimdHTML.NeonMatch(start, end);
-                        while (match.Advance())
-                        {
-                            count += *match.Get();
-                            match.Consume();
-                        }
-
-                    }
-                }
-            }
-            return count;
-        }
-
-
-
-        [Benchmark]
-        [BenchmarkCategory("default")]
-        public unsafe int NEON64HTMLScan()
-        {
-            int count = 0;
-            if (allLinesUtf8 != null && AdvSimd.Arm64.IsSupported)
-            {
-
-                unsafe
-                {
-                    fixed (byte* pUtf8 = allLinesUtf8)
-                    {
-                        byte* start = pUtf8;
-                        byte* end = pUtf8 + allLinesUtf8.Length;
-                        SimdHTML.NeonMatch64 match = new SimdHTML.NeonMatch64(start, end);
-                        while (match.Advance())
-                        {
-                            count += *match.Get();
-                            match.Consume();
-                        }
-
-                    }
-                }
-            }
-            return count;
-        }
-
-        [Benchmark]
-        [BenchmarkCategory("default")]
-
-        public unsafe int HTMLScan()
-        {
-            int count = 0;
-
-            if (allLinesUtf8 != null)
-            {
-                unsafe
-                {
-                    fixed (byte* pUtf8 = allLinesUtf8)
-                    {
-                        byte* start = pUtf8;
-                        byte* end = pUtf8 + allLinesUtf8.Length;
-                        while (start != end)
-                        {
-                            SimdHTML.FastScan.NaiveAdvanceString(ref start, end);
-                            if (start == end)
-                            {
-                                break;
-                            }
-                            count += *start;
-                            start++;
-                        }
-                    }
-                }
-            }
-            return count;
-        }
-        private static readonly SearchValues<byte> searchValues = SearchValues.Create(stackalloc byte[] { 0, 13, 38, 60 });
-
-        [Benchmark]
-        [BenchmarkCategory("default")]
-
-        public unsafe int SearchValuesBench()
-        {
-            int count = 0;
-            if (allLinesUtf8 != null)
-            {
-                unsafe
-                {
-                    ReadOnlySpan<byte> data = allLinesUtf8;
-                    while (!data.IsEmpty)
-                    {
-                        int first = data.IndexOfAny(searchValues);
-                        data = data.Slice(first >= 0 ? first + 1 : 1);
-                        if (first >= 0) count += data[0];
-                    }
-
-                }
-            }
-            return count;
-        }
-
+        return count;
     }
 
-
-
-    public class Program
+    [Benchmark]
+    public unsafe int NEONHTMLScan()
     {
-        static void Main(string[] args)
+        int count = 0;
+        if (allLinesUtf8 != null && AdvSimd.Arm64.IsSupported)
         {
-            if (args.Length == 0)
-            {
-                args = new string[] { "--filter", "*" };
-            }
-            var job = Job.Default
-                .WithWarmupCount(1)
-                .WithMinIterationCount(2)
-                .WithMaxIterationCount(10)
-                .AsDefault();
 
-            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, DefaultConfig.Instance.AddJob(job).WithSummaryStyle(SummaryStyle.Default.WithMaxParameterColumnWidth(100)));
+            unsafe
+            {
+                fixed (byte* pUtf8 = allLinesUtf8)
+                {
+                    byte* start = pUtf8;
+                    byte* end = pUtf8 + allLinesUtf8.Length;
+                    SimdHTML.NeonMatch match = new SimdHTML.NeonMatch(start, end);
+                    while (match.Advance())
+                    {
+                        count += *match.Get();
+                        match.Consume();
+                    }
+
+                }
+            }
         }
+        return count;
     }
 
+    [Benchmark]
+    public unsafe int NEON64HTMLScan()
+    {
+        int count = 0;
+        if (allLinesUtf8 != null && AdvSimd.Arm64.IsSupported)
+        {
+            fixed (byte* pUtf8 = allLinesUtf8)
+            {
+                var start = pUtf8;
+                var end = pUtf8 + allLinesUtf8.Length;
+                var scanner = new Neon64Scanner(start, end);
+                foreach (var match in scanner)
+                {
+                    count += *match;
+                }
+            }
+        }
+        return count;
+    }
 
-    //  }
+    [Benchmark]
+    public unsafe int HTMLScan()
+    {
+        int count = 0;
+
+        if (allLinesUtf8 != null)
+        {
+            unsafe
+            {
+                fixed (byte* pUtf8 = allLinesUtf8)
+                {
+                    byte* start = pUtf8;
+                    byte* end = pUtf8 + allLinesUtf8.Length;
+                    while (start != end)
+                    {
+                        SimdHTML.FastScan.NaiveAdvanceString(ref start, end);
+                        if (start == end)
+                        {
+                            break;
+                        }
+                        count += *start;
+                        start++;
+                    }
+                }
+            }
+        }
+        return count;
+    }
+
+    static readonly SearchValues<byte> searchValues = SearchValues.Create([0, 13, 38, 60]);
+
+    [Benchmark]
+    public unsafe int SearchValuesBench()
+    {
+        int count = 0;
+        if (allLinesUtf8 != null)
+        {
+            unsafe
+            {
+                ReadOnlySpan<byte> data = allLinesUtf8;
+                while (!data.IsEmpty)
+                {
+                    int first = data.IndexOfAny(searchValues);
+                    data = data.Slice(first >= 0 ? first + 1 : 1);
+                    if (first >= 0) count += data[0];
+                }
+
+            }
+        }
+        return count;
+    }
 
 }

--- a/2024/07/05/benchmark/benchmark.csproj
+++ b/2024/07/05/benchmark/benchmark.csproj
@@ -2,20 +2,20 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+    <ImplicitUsings>enable</ImplicitUsings>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\src\SimdHTML.csproj" />
+    <ProjectReference Include="..\..\..\..\extra\dotnet\utils\Utils.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/2024/07/05/src/SimdHTML.cs
+++ b/2024/07/05/src/SimdHTML.cs
@@ -1,137 +1,161 @@
-using System;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 using System.Runtime.Intrinsics.Arm;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Numerics;
-namespace SimdHTML
+
+namespace SimdHTML;
+
+// modified by Arseniy Zlobintsev
+public unsafe struct Neon64Scanner(byte* start, byte* end)
 {
+    static Vector128<byte> V0F => Vector128.Create((byte)0x0F);
+    static Vector128<byte> LowNibbleMask => Vector128.Create((byte)
+        0, 0, 0, 0, 0, 0, 0x26, 0, 0, 0, 0, 0, 0x3c, 0xd, 0, 0);
+    static Vector128<byte> BitMask => Vector128.Create(
+        0x01, 0x02, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80,
+        0x01, 0x02, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80);
 
+    ulong matches;
+    int offset;
 
-    public unsafe sealed class NeonMatch64
+    // C# allows duck-typed matching on IEnumerable<T> signatures for foreach
+    public Neon64Scanner GetEnumerator() => this;
+
+    // Usually this is an anti-pattern: IEnumerator<T>.Current
+    // should be side-effect free. However, because this is a low-level
+    // type, we can make an exception.
+    public byte* Current
     {
-
-        private byte* _start;
-        private readonly byte* _end;
-        private int _offset;
-        private UInt64 _matches;
-        private static readonly Vector128<byte> v0f = Vector128.Create((byte)0x0F);
-        private static readonly Vector128<byte> low_nibble_mask = Vector128.Create(0, 0, 0, 0, 0, 0, (byte)0x26, 0, 0, 0, 0, 0, (byte)0x3c, (byte)0xd, 0, 0);
-        private static readonly Vector128<byte> bit_mask = Vector128.Create(0x01, 0x02, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80, 0x01, 0x02, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80);
-
-        public NeonMatch64(byte* start, byte* end)
+        get
         {
-            _start = start;
-            _end = end;
+            var curr = start + offset;
+            matches >>= 1;
+            offset++;
+            return curr;
+        }
+    }
 
-            _offset = 0;
-            _matches = 0;
-
-            if (_start + 64 >= _end)
+    public bool MoveNext()
+    {
+        while (matches is 0)
+        {
+            var ptr = start;
+            if (ptr + 64 < end)
             {
-                carefulUpdate();
+                matches = Scan(ptr);
+                start = ptr + 64;
+                offset = 0;
             }
             else
             {
-                Update();
-            }
-        }
-
-        public byte* Get() => _start + _offset;
-
-        public void Consume()
-        {
-            _offset++;
-            _matches >>= 1;
-        }
-
-        public bool Advance()
-        {
-            while (_matches == 0)
-            {
-                _start += 64;
-
-                if (_start + 64 >= _end)
+                if (ptr >= end)
                 {
-                    if (_start >= _end)
-                    {
-                        return false;
-                    }
-                    carefulUpdate();
-                    if (_matches == 0)
-                    {
-                        return false;
-                    }
+                    return false;
                 }
-                else
+
+                matches = ScanShort(ptr, end);
+                start = end;
+                offset = 0;
+
+                if (matches is 0)
                 {
-                    Update();
+                    return false;
                 }
             }
-
-            int off = BitOperations.TrailingZeroCount(_matches);
-            _matches >>= off;
-            _offset += off;
-            return true;
         }
 
-        private void carefulUpdate()
-        {
-            Span<byte> buffer = stackalloc byte[64];
-            buffer.Fill(1);
-            fixed (byte* ptr = buffer)
-            {
-                Buffer.MemoryCopy(_start, ptr, 64, _end - _start);
-                Update(ptr);
-            }
-        }
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void Update() => Update(_start);
+        var off = BitOperations.TrailingZeroCount(matches);
+        matches >>= off;
+        offset += off;
+        return true;
+    }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void Update(byte* s)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static ulong Scan(byte* s)
+    {
+        var (data1, data2, data3, data4) = AdvSimd.Arm64.Load4xVector128(s);
+        var lowpart1 = AdvSimd.Arm64.VectorTableLookup(LowNibbleMask, data1 & V0F);
+        var lowpart2 = AdvSimd.Arm64.VectorTableLookup(LowNibbleMask, data2 & V0F);
+        var lowpart3 = AdvSimd.Arm64.VectorTableLookup(LowNibbleMask, data3 & V0F);
+        var lowpart4 = AdvSimd.Arm64.VectorTableLookup(LowNibbleMask, data4 & V0F);
+        var matchesones1 = Vector128.Equals(lowpart1, data1);
+        var matchesones2 = Vector128.Equals(lowpart2, data2);
+        var matchesones3 = Vector128.Equals(lowpart3, data3);
+        var matchesones4 = Vector128.Equals(lowpart4, data4);
+        var sum0 = AdvSimd.Arm64.AddPairwise(matchesones1 & BitMask, matchesones2 & BitMask);
+        var sum1 = AdvSimd.Arm64.AddPairwise(matchesones3 & BitMask, matchesones4 & BitMask);
+        sum0 = AdvSimd.Arm64.AddPairwise(sum0, sum1);
+        sum0 = AdvSimd.Arm64.AddPairwise(sum0, sum0);
+        return sum0.AsUInt64().ToScalar();
+    }
+
+    static ulong ScanShort(byte* s, byte* end)
+    {
+        var buffer = (stackalloc byte[64]);
+        buffer.Fill(1);
+
+        var length = (int)(uint)(end - s);
+        new Span<byte>(s, length).CopyTo(buffer);
+
+        fixed (byte* ptr = buffer) return Scan(ptr);
+    }
+}
+
+public unsafe struct NeonMatch
+{
+    private byte* _start;
+    private readonly byte* _end;
+    private int _offset;
+    private ulong _matches;
+
+    private static readonly Vector128<byte> v0f = Vector128.Create((byte)0x0F);
+    private static readonly Vector128<byte> low_nibble_mask = Vector128.Create(0, 0, 0, 0, 0, 0, (byte)0x26, 0, 0, 0, 0, 0, (byte)0x3c, (byte)0xd, 0, 0);
+
+    public NeonMatch(byte* start, byte* end)
+    {
+        _start = start;
+        _end = end;
+        _offset = 0;
+        _matches = 0;
+
+        if (_start + 16 >= _end)
         {
-            Vector128<byte> data1 = AdvSimd.LoadVector128(s);
-            Vector128<byte> data2 = AdvSimd.LoadVector128(s + 16);
-            Vector128<byte> data3 = AdvSimd.LoadVector128(s + 32);
-            Vector128<byte> data4 = AdvSimd.LoadVector128(s + 48);
-            Vector128<byte> lowpart1 = AdvSimd.Arm64.VectorTableLookup(low_nibble_mask, data1 & v0f);
-            Vector128<byte> lowpart2 = AdvSimd.Arm64.VectorTableLookup(low_nibble_mask, data2 & v0f);
-            Vector128<byte> lowpart3 = AdvSimd.Arm64.VectorTableLookup(low_nibble_mask, data3 & v0f);
-            Vector128<byte> lowpart4 = AdvSimd.Arm64.VectorTableLookup(low_nibble_mask, data4 & v0f);
-            Vector128<byte> matchesones1 = AdvSimd.CompareEqual(lowpart1, data1);
-            Vector128<byte> matchesones2 = AdvSimd.CompareEqual(lowpart2, data2);
-            Vector128<byte> matchesones3 = AdvSimd.CompareEqual(lowpart3, data3);
-            Vector128<byte> matchesones4 = AdvSimd.CompareEqual(lowpart4, data4);
-            Vector128<byte> sum0 = AdvSimd.Arm64.AddPairwise(matchesones1 & bit_mask, matchesones2 & bit_mask);
-            Vector128<byte> sum1 = AdvSimd.Arm64.AddPairwise(matchesones3 & bit_mask, matchesones4 & bit_mask);
-            sum0 = AdvSimd.Arm64.AddPairwise(sum0, sum1);
-            sum0 = AdvSimd.Arm64.AddPairwise(sum0, sum0);
-            _matches = sum0.AsUInt64().ToScalar();
-            _offset = 0;
+            carefulUpdate();
+        }
+        else
+        {
+            Update();
         }
     }
-    public unsafe sealed class NeonMatch
+
+    public byte* Get() => _start + _offset;
+
+    public void Consume()
     {
-        private byte* _start;
-        private readonly byte* _end;
-        private int _offset;
-        private ulong _matches;
+        _offset++;
+        _matches >>= 4;
+    }
 
-        private static readonly Vector128<byte> v0f = Vector128.Create((byte)0x0F);
-        private static readonly Vector128<byte> low_nibble_mask = Vector128.Create(0, 0, 0, 0, 0, 0, (byte)0x26, 0, 0, 0, 0, 0, (byte)0x3c, (byte)0xd, 0, 0);
-
-        public NeonMatch(byte* start, byte* end)
+    public bool Advance()
+    {
+        while (_matches == 0)
         {
-            _start = start;
-            _end = end;
-            _offset = 0;
-            _matches = 0;
+            _start += 16;
+
 
             if (_start + 16 >= _end)
             {
+                if (_start >= _end)
+                {
+                    return false;
+                }
                 carefulUpdate();
+
+                if (_matches == 0)
+                {
+                    return false;
+                }
             }
             else
             {
@@ -139,198 +163,173 @@ namespace SimdHTML
             }
         }
 
-        public byte* Get() => _start + _offset;
+        int off = BitOperations.TrailingZeroCount(_matches);
+        _matches >>= off;
+        _offset += off >> 2;
+        return true;
+    }
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void carefulUpdate()
+    {
+        // 'stackalloc' blocks inlining because it is
+        // a very special construct which emits a
+        // stack cookie to guard against stack overruns
+        // and inserts a failfast path should that happen.
+        // use "inline array" instead which is automatically
+        // emitted by Roslyn (C# compiler) for idioms like this.
+        Span<byte> buffer =
+        [
+            1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1
+        ];
 
-        public void Consume()
+        fixed (byte* ptr = buffer)
         {
-            _offset++;
-            _matches >>= 4;
+            Buffer.MemoryCopy(_start, ptr, 16, _end - _start);
+            Update(ptr);
         }
+    }
+    private void Update() => Update(_start);
 
-        public bool Advance()
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void Update(byte* s)
+    {
+        Vector128<byte> data = AdvSimd.LoadVector128(s);
+        Vector128<byte> lowpart = AdvSimd.Arm64.VectorTableLookup(low_nibble_mask, data & v0f);
+        Vector128<byte> matchesones = AdvSimd.CompareEqual(lowpart, data);
+        _matches = AdvSimd.ShiftRightLogicalNarrowingLower(matchesones.AsUInt16(), 4).AsUInt64().ToScalar();
+        _offset = 0;
+    }
+
+}
+public static class FastScan
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public unsafe static void NaiveAdvanceString(ref byte* startm, byte* end)
+    {
+        byte* start = startm;
+        while (start < end)
         {
-            while (_matches == 0)
+            if (*start == '<' || *start == '&' || *start == '\r' || *start == '\0')
             {
-                _start += 16;
-
-
-                if (_start + 16 >= _end)
-                {
-                    if (_start >= _end)
-                    {
-                        return false;
-                    }
-                    carefulUpdate();
-
-                    if (_matches == 0)
-                    {
-                        return false;
-                    }
-                }
-                else
-                {
-                    Update();
-                }
+                startm = start;
+                return;
             }
-
-            int off = BitOperations.TrailingZeroCount(_matches);
-            _matches >>= off;
-            _offset += off >> 2;
-            return true;
-        }
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void carefulUpdate()
-        {
-            Span<byte> buffer = stackalloc byte[16];
-            buffer.Fill(1);
-            fixed (byte* ptr = buffer)
-            {
-                Buffer.MemoryCopy(_start, ptr, 16, _end - _start);
-                Update(ptr);
-            }
-        }
-        private void Update() => Update(_start);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-
-        private void Update(byte* s)
-        {
-            Vector128<byte> data = AdvSimd.LoadVector128(s);
-            Vector128<byte> lowpart = AdvSimd.Arm64.VectorTableLookup(low_nibble_mask, data & v0f);
-            Vector128<byte> matchesones = AdvSimd.CompareEqual(lowpart, data);
-            _matches = AdvSimd.ShiftRightLogicalNarrowingLower(matchesones.AsUInt16(), 4).AsUInt64().ToScalar();
-            _offset = 0;
+            start++;
         }
 
     }
-    public static class FastScan
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public unsafe static void SIMDAdvanceString(ref byte* startm, byte* end)
     {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe static void NaiveAdvanceString(ref byte* startm, byte* end)
+        byte* start = startm;
+        if (AdvSimd.Arm64.IsSupported)
         {
-            byte* start = startm;
-            while (start < end)
+            Vector128<byte> low_nibble_mask = Vector128.Create(0, 0, 0, 0, 0, 0, (byte)0x26, 0, 0, 0, 0, 0, (byte)0x3c, (byte)0xd, 0, 0);
+            Vector128<byte> v0f = Vector128.Create((byte)0x0F);
+            Vector128<byte> bit_mask = Vector128.Create((byte)16, 15, 14, 13, 12, 11, 10, 9, 8,
+                                7, 6, 5, 4, 3, 2, 1);
+
+            const int stride = 16;
+            while (start + (stride - 1) < end)
             {
-                if (*start == '<' || *start == '&' || *start == '\r' || *start == '\0')
+                Vector128<byte> data = AdvSimd.LoadVector128((byte*)start);
+                Vector128<byte> lowpart = AdvSimd.Arm64.VectorTableLookup(low_nibble_mask, data & v0f);
+                Vector128<byte> matchesones = AdvSimd.CompareEqual(lowpart, data);
+                if (matchesones != Vector128<byte>.Zero)
                 {
+                    Vector128<byte> matches = AdvSimd.And(bit_mask, matchesones);
+                    int m = AdvSimd.Arm64.MaxAcross(matches).ToScalar();
+                    start += 16 - m;
                     startm = start;
                     return;
                 }
-                start++;
+                start += stride;
             }
-
         }
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe static void SIMDAdvanceString(ref byte* startm, byte* end)
+        // We deliberately disable it
+        else if (false) // Vector512.IsHardwareAccelerated && Avx512F.IsSupported && Avx512BW.IsSupported && Avx512Vbmi.IsSupported)
         {
-            byte* start = startm;
-            if (AdvSimd.Arm64.IsSupported)
+            Vector512<byte> low_nibble_lut = Vector512.Create(0, 0, 0, 0, 0, 0, (byte)0x26, 0, 0, 0, 0, 0, (byte)0x3c, (byte)0xd, 0, 0,
+            0, 0, 0, 0, 0, 0, (byte)0x26, 0, 0, 0, 0, 0, (byte)0x3c, (byte)0xd, 0, 0,
+            0, 0, 0, 0, 0, 0, (byte)0x26, 0, 0, 0, 0, 0, (byte)0x3c, (byte)0xd, 0, 0,
+            0, 0, 0, 0, 0, 0, (byte)0x26, 0, 0, 0, 0, 0, (byte)0x3c, (byte)0xd, 0, 0);
+            const int stride = 64;
+            while (start + (stride - 1) < end)
             {
-                Vector128<byte> low_nibble_mask = Vector128.Create(0, 0, 0, 0, 0, 0, (byte)0x26, 0, 0, 0, 0, 0, (byte)0x3c, (byte)0xd, 0, 0);
-                Vector128<byte> v0f = Vector128.Create((byte)0x0F);
-                Vector128<byte> bit_mask = Vector128.Create((byte)16, 15, 14, 13, 12, 11, 10, 9, 8,
-                                    7, 6, 5, 4, 3, 2, 1);
-
-                const int stride = 16;
-                while (start + (stride - 1) < end)
+                Vector512<byte> data = Avx512F.LoadVector512((byte*)start);
+                Vector512<byte> transform = Avx512BW.Shuffle(low_nibble_lut, data);
+                Vector512<byte> matches_transform = Avx512BW.CompareEqual(transform, data);
+                UInt64 mask = matches_transform.ExtractMostSignificantBits(); ;
+                if (mask != 0)
                 {
-                    Vector128<byte> data = AdvSimd.LoadVector128((byte*)start);
-                    Vector128<byte> lowpart = AdvSimd.Arm64.VectorTableLookup(low_nibble_mask, data & v0f);
-                    Vector128<byte> matchesones = AdvSimd.CompareEqual(lowpart, data);
-                    if (matchesones != Vector128<byte>.Zero)
-                    {
-                        Vector128<byte> matches = AdvSimd.And(bit_mask, matchesones);
-                        int m = AdvSimd.Arm64.MaxAcross(matches).ToScalar();
-                        start += 16 - m;
-                        startm = start;
-                        return;
-                    }
-                    start += stride;
+                    start += BitOperations.TrailingZeroCount(mask);
+                    startm = start;
+                    return;
                 }
+                start += stride;
             }
-            // We deliberately disable it
-            else if (false) // Vector512.IsHardwareAccelerated && Avx512F.IsSupported && Avx512BW.IsSupported && Avx512Vbmi.IsSupported)
-            {
-                Vector512<byte> low_nibble_lut = Vector512.Create(0, 0, 0, 0, 0, 0, (byte)0x26, 0, 0, 0, 0, 0, (byte)0x3c, (byte)0xd, 0, 0,
-                0, 0, 0, 0, 0, 0, (byte)0x26, 0, 0, 0, 0, 0, (byte)0x3c, (byte)0xd, 0, 0,
-                0, 0, 0, 0, 0, 0, (byte)0x26, 0, 0, 0, 0, 0, (byte)0x3c, (byte)0xd, 0, 0,
+        }
+        else if (Avx2.IsSupported)
+        {
+            // credit : Harold Aptroot
+            Vector128<byte> low_nibble_lut128 = Vector128.Create(
                 0, 0, 0, 0, 0, 0, (byte)0x26, 0, 0, 0, 0, 0, (byte)0x3c, (byte)0xd, 0, 0);
-                const int stride = 64;
-                while (start + (stride - 1) < end)
-                {
-                    Vector512<byte> data = Avx512F.LoadVector512((byte*)start);
-                    Vector512<byte> transform = Avx512BW.Shuffle(low_nibble_lut, data);
-                    Vector512<byte> matches_transform = Avx512BW.CompareEqual(transform, data);
-                    UInt64 mask = matches_transform.ExtractMostSignificantBits(); ;
-                    if (mask != 0)
-                    {
-                        start += BitOperations.TrailingZeroCount(mask);
-                        startm = start;
-                        return;
-                    }
-                    start += stride;
-                }
-            }
-            else if (Avx2.IsSupported)
+            Vector256<byte> low_nibble_lut = Vector256.Create(low_nibble_lut128, low_nibble_lut128);
+
+
+            const int stride = 32;
+            while (start + (stride - 1) < end)
             {
-                // credit : Harold Aptroot
-                Vector128<byte> low_nibble_lut128 = Vector128.Create(
-                    0, 0, 0, 0, 0, 0, (byte)0x26, 0, 0, 0, 0, 0, (byte)0x3c, (byte)0xd, 0, 0);
-                Vector256<byte> low_nibble_lut = Vector256.Create(low_nibble_lut128, low_nibble_lut128);
-
-
-                const int stride = 32;
-                while (start + (stride - 1) < end)
+                Vector256<byte> data = Avx2.LoadVector256((byte*)start);
+                Vector256<byte> transform = Avx2.Shuffle(low_nibble_lut, data);
+                Vector256<byte> matches_transform = Avx2.CompareEqual(transform, data);
+                int mask = Avx2.MoveMask(matches_transform);
+                if (mask != 0)
                 {
-                    Vector256<byte> data = Avx2.LoadVector256((byte*)start);
-                    Vector256<byte> transform = Avx2.Shuffle(low_nibble_lut, data);
-                    Vector256<byte> matches_transform = Avx2.CompareEqual(transform, data);
-                    int mask = Avx2.MoveMask(matches_transform);
-                    if (mask != 0)
-                    {
-                        start += BitOperations.TrailingZeroCount(mask);
-                        startm = start;
-                        return;
-                    }
-                    start += stride;
-                }
-            }
-            else if (Ssse3.IsSupported)
-            {
-                // credit : Harold Aptroot
-                Vector128<byte> low_nibble_lut = Vector128.Create(
-                    0, 0, 0, 0, 0, 0, (byte)0x26, 0, 0, 0, 0, 0, (byte)0x3c, (byte)0xd, 0, 0);
-                const int stride = 16;
-                while (start + (stride - 1) < end)
-                {
-                    Vector128<byte> data = Sse2.LoadVector128((byte*)start);
-                    // for bytes < 0x80, lookup based on the lowest nibble
-                    // for bytes >= 0x80, zero
-                    Vector128<byte> transform = Ssse3.Shuffle(low_nibble_lut, data);
-                    // only for 0, 0x26, 0x3C, 0x0D will the transformed value match the original
-                    Vector128<byte> matches_transform = Sse2.CompareEqual(transform, data);
-                    int mask = Sse2.MoveMask(matches_transform);
-                    if (mask != 0)
-                    {
-                        start += BitOperations.TrailingZeroCount(mask);
-                        startm = start;
-                        return;
-                    }
-                    start += stride;
-                }
-            }
-
-
-            while (start < end)
-            {
-                if (*start == '<' || *start == '&' || *start == '\r' || *start == '\0')
-                {
+                    start += BitOperations.TrailingZeroCount(mask);
                     startm = start;
                     return;
                 }
-                start++;
+                start += stride;
             }
-            startm = start;
         }
+        else if (Ssse3.IsSupported)
+        {
+            // credit : Harold Aptroot
+            Vector128<byte> low_nibble_lut = Vector128.Create(
+                0, 0, 0, 0, 0, 0, (byte)0x26, 0, 0, 0, 0, 0, (byte)0x3c, (byte)0xd, 0, 0);
+            const int stride = 16;
+            while (start + (stride - 1) < end)
+            {
+                Vector128<byte> data = Sse2.LoadVector128((byte*)start);
+                // for bytes < 0x80, lookup based on the lowest nibble
+                // for bytes >= 0x80, zero
+                Vector128<byte> transform = Ssse3.Shuffle(low_nibble_lut, data);
+                // only for 0, 0x26, 0x3C, 0x0D will the transformed value match the original
+                Vector128<byte> matches_transform = Sse2.CompareEqual(transform, data);
+                int mask = Sse2.MoveMask(matches_transform);
+                if (mask != 0)
+                {
+                    start += BitOperations.TrailingZeroCount(mask);
+                    startm = start;
+                    return;
+                }
+                start += stride;
+            }
+        }
+
+
+        while (start < end)
+        {
+            if (*start == '<' || *start == '&' || *start == '\r' || *start == '\0')
+            {
+                startm = start;
+                return;
+            }
+            start++;
+        }
+        startm = start;
     }
 }
 

--- a/2024/07/05/src/SimdHTML.csproj
+++ b/2024/07/05/src/SimdHTML.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+    <ImplicitUsings>enable</ImplicitUsings>
     <!-- This is required for SIMD, sse c# - How to run unsafe code in "visual studio code"? - Stack Overflow https://stackoverflow.com/questions/50636693/how-to-run-unsafe-code-in-visual-studio-code -->
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks> 
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>
 
 </Project>

--- a/extra/dotnet/utils/Benchmark/SpeedColumn.cs
+++ b/extra/dotnet/utils/Benchmark/SpeedColumn.cs
@@ -1,0 +1,44 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Running;
+
+namespace Utils.Benchmark;
+
+public class SpeedColumnAttribute : ColumnConfigBaseAttribute
+{
+    public SpeedColumnAttribute() : base(new Speed()) { } 
+}
+
+public class Speed : IColumn
+{
+    public string GetValue(Summary summary, BenchmarkCase benchmarkCase)
+    {
+        if (summary is null || benchmarkCase is null || benchmarkCase.Parameters is null)
+        {
+            return "N/A";
+        }
+        var ourReport = summary.Reports.First(x => x.BenchmarkCase.Equals(benchmarkCase));
+        var fileName = (string)benchmarkCase.Parameters["FileName"];
+        if (ourReport is null || ourReport.ResultStatistics is null)
+        {
+            return "N/A";
+        }
+        var length = new FileInfo(fileName).Length;
+        var mean = ourReport.ResultStatistics.Mean;
+        return $"{length / ourReport.ResultStatistics.Mean:#####.00}";
+    }
+
+    public string GetValue(Summary summary, BenchmarkCase benchmarkCase, SummaryStyle style) => GetValue(summary, benchmarkCase);
+    public bool IsDefault(Summary summary, BenchmarkCase benchmarkCase) => false;
+    public bool IsAvailable(Summary summary) => true;
+
+    public string Id { get; } = nameof(Speed);
+    public string ColumnName { get; } = "Speed (GB/s)";
+    public bool AlwaysShow { get; } = true;
+    public ColumnCategory Category { get; } = ColumnCategory.Custom;
+    public int PriorityInCategory { get; }
+    public bool IsNumeric { get; }
+    public UnitType UnitType { get; } = UnitType.Dimensionless;
+    public string Legend { get; } = "The speed in gigabytes per second";
+}

--- a/extra/dotnet/utils/Utils.csproj
+++ b/extra/dotnet/utils/Utils.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This pull-request includes the following changes. For better reviewing experience, consider using "ignore whitespace" option. Thanks!

#### Refactor `Neon64Match` into an idiomatic enumerator 

C# supports regular (implementing `IEnumerable<T>` interface) and duck-typed enumerators.
Therefore, instead of C++-style custom loop, a regular `foreach (var match in ...` can be used instead.
Additionally, make scanning methods and state mutation ones separate - instance methods on structs take them
by reference, and this tends to, sometimes, make the compiler output worse because it forces struct contents
onto the stack instead of keeping them in registers at all times. This is an area where .NET has significantly closed the gap
with LLVM and GCC starting with version 8, but it is more fragile still, so we have to help it out occasionally.

Notably, `stackalloc` is a very special keyword which inserts stack cookie to guard against stack overrun with a
fail-fast path should that happen. It also prevents or severely limits method inlining. Because `CarefulUpdate` was
an instance method, it means that an un-inlineable method was taking `Neon64Match` by reference and was
forcing it to be spilled onto the stack which was degrading the quality of the loop significantly.

#### Make iterator-like types in `SimdHTML.cs` structs

This is important because, unlike OpenJDK, .NET has weaker escape analysis (it *just* gained such capability properly in .NET 9 preview). Of course .NET is a much lower level platform so historically this has almost never been an issue as structs vs classes distinction always clearly communicated how the type is supposed to be handled.

Just for the sake of clarity, .NET classes are strictly reference types and are more akin to `Box<TClassLayout>` as the Rust names it, they are distinct from C++ classes which might cause confusion.

This means that a state of an iterator that is a class will have to be reloaded per-iteration, and the current rendition of escape analysis is unable to see that it is entirely thread-private and remove reloading the data from/to heap.

#### Simplify benchmark code

I have opted to move out repeated `Speed` column code into a `Utils` project. Should you ever need it, you can simply `dotnet add reference path/to/folder/with/utils/project` and then annotate the benchmark fixture that you want to add it to. It would still look for `FileName` field as it does right now.

Also I made other cosmetic adjustments to reduce the line count - BenchmarkDotNet configurability is a bit of a mess, but the "happy-path" does not need as many LOC. I have also recreated .sln to make it correct and updated .gitignore.

Lastly, the project target was bumped to net9.0 (preview). If you are okay with it, please make sure to get the latest preview from https://dotnet.microsoft.com/en-us/download/dotnet/9.0. If not - please let me know.

#### Numbers

```
BenchmarkDotNet v0.13.12, macOS 15.0 (24A5289h) [Darwin 24.0.0]
Apple M1 Pro, 1 CPU, 8 logical and 8 physical cores
.NET SDK 9.0.100-preview.7.24367.22
  [Host]     : .NET 9.0.0 (9.0.24.36618), Arm64 RyuJIT AdvSIMD
  Job-WIRYJV : .NET 9.0.0 (9.0.24.36618), Arm64 RyuJIT AdvSIMD

IterationCount=6  LaunchCount=1  WarmupCount=3  
```

| Method            | FileName       | Mean        | Error    | StdDev   | Speed (GB/s) |
|------------------ |--------------- |------------:|---------:|---------:|------------- |
| SIMDHTMLScan      | data/data.html |  3,508.4 ns | 10.47 ns |  2.72 ns | 5.79         |
| NEONHTMLScan      | data/data.html |    875.0 ns |  1.68 ns |  0.60 ns | 23.22        |
| NEON64HTMLScan    | data/data.html |    734.9 ns |  0.97 ns |  0.25 ns | 27.65        |
| HTMLScan          | data/data.html | 15,666.6 ns | 98.12 ns | 25.48 ns | 1.30         |
| SearchValuesBench | data/data.html |  4,964.8 ns | 26.13 ns |  9.32 ns | 4.09         |

Sadly, this seems to ruin nice improvement over not unrolled variant in `NEONHTMLScan`. It appears currently implementation does not extract as much load throughput from M-series as theoretically achievable. Possible areas of exploration can be fast multi-vector table lookups that it supports, or making the implementation less fancy, I think. Current implementation seems to be generally inspired by how `movmask` works, and it's always a bit painful for patterns where SSE/AVX fit perfectly :)