### PR TITLE
Remove per invocation setup

### DIFF
--- a/2024/10/14/src/main/java/me/lemire/MyBenchmark.java
+++ b/2024/10/14/src/main/java/me/lemire/MyBenchmark.java
@@ -152,10 +152,6 @@ public class MyBenchmark {
             }
             outputstring = new char[count];
         }
-
-        @Setup(Level.Invocation)
-        public void perInvocation(){
-        }
     }
 
     @Benchmark


### PR DESCRIPTION
per invocations call can mess up badly with performance although empty (depends if got DCE) - it's safer to remove it
PTAL @lemire 