### PR TITLE
It improves the test in order to make both reproducible and correct numbers

### DIFF
--- a/2024/10/14/pom.xml
+++ b/2024/10/14/pom.xml
@@ -87,8 +87,8 @@ THE POSSIBILITY OF SUCH DAMAGE.
 
                 <configuration>
                     <compilerVersion>${javac.target}</compilerVersion>
-                    <source>${javac.target}</source>
-                    <target>${javac.target}</target>
+                    <source>17</source>
+                    <target>17</target>
                     <compilerArgs>
                     <arg>-processor</arg>
                     <arg>org.openjdk.jmh.generators.BenchmarkProcessor</arg>

--- a/2024/10/14/src/main/java/me/lemire/MyBenchmark.java
+++ b/2024/10/14/src/main/java/me/lemire/MyBenchmark.java
@@ -4,7 +4,9 @@ import org.openjdk.jmh.annotations.Benchmark;
 
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
-import java.util.concurrent.ThreadLocalRandom;
+
+import java.util.random.RandomGenerator;
+import java.util.random.RandomGeneratorFactory;
 
 @Measurement(iterations = 10, time = 1)
 @Warmup(iterations = 5, time = 1)
@@ -51,17 +53,21 @@ public class MyBenchmark {
     }
 
     public static int replaceBackslashTable1(char[] original, char[] newArray) {
-        int index = 0;
+        int newArrayLength = 0;
         for (char c : original) {
-            byte b = silly_table1[c%256];
-            if (c < 256 &&  b != 0) {
-                newArray[index++] = '\\';
-                newArray[index++] = (char)b;
+            // copy regardless into output; this allow the loop to be unrolled ;)
+            newArray[newArrayLength] = c;
+            byte b = silly_table1[c % 256];
+            if (c < 256 && b != 0) {
+                // we need to copy from the last known index to the current one, excluded
+                newArray[newArrayLength] = '\\';
+                newArray[newArrayLength + 1] = (char) b;
+                newArrayLength += 2;
             } else {
-                newArray[index++] = c;
+                newArrayLength++;
             }
         }
-        return index;
+        return newArrayLength;
     }
 
 
@@ -82,17 +88,21 @@ public class MyBenchmark {
     }
 
     public static int replaceBackslashTable2(char[] original, char[] newArray) {
-        int index = 0;
+        int newArrayLength = 0;
         for (char c : original) {
-            byte b = silly_table2[c%256];
-            if (c < 256 &&  b > 0) {
-                newArray[index++] = '\\';
-                newArray[index++] = (char)b;
+            // copy regardless into output; this allow the loop to be unrolled ;)
+            newArray[newArrayLength] = c;
+            byte b = silly_table2[c % 256];
+            if (c < 256 && b != 0) {
+                // we need to copy from the last known index to the current one, excluded
+                newArray[newArrayLength] = '\\';
+                newArray[newArrayLength + 1] = (char) b;
+                newArrayLength += 2;
             } else {
-                newArray[index++] = c;
+                newArrayLength++;
             }
         }
-        return index;
+        return newArrayLength;
     }
 
     public static int replaceBackslash3(char[] original, char[] newArray) {
@@ -115,21 +125,29 @@ public class MyBenchmark {
     }
 
     public static int replaceBackslashTable3(char[] original, char[] newArray) {
-        int index = 0;
+        int newArrayLength = 0;
         for (char c : original) {
-            byte b = silly_table3[c%256];
-            if (c < 256 && b > 0) {
-                newArray[index++] = '\\';
-                newArray[index++] = (char)b;
+            // copy regardless into output; this allow the loop to be unrolled ;)
+            newArray[newArrayLength] = c;
+            byte b = silly_table3[c % 256];
+            if (c < 256 && b != 0) {
+                // we need to copy from the last known index to the current one, excluded
+                newArray[newArrayLength] = '\\';
+                newArray[newArrayLength + 1] = (char) b;
+                newArrayLength += 2;
             } else {
-                newArray[index++] = c;
+                newArrayLength++;
             }
         }
-        return index;
+        return newArrayLength;
     }
 
     @State(Scope.Benchmark)
     public static class BenchmarkState {
+
+        // better be safe and keep it the same to have reproducible results
+        private static final int SEED = 42;
+
         @Param({"65536"})
         public int size;
         public char[] inputstring;
@@ -138,12 +156,13 @@ public class MyBenchmark {
 
         @Setup(Level.Trial)
         public void setUp() {
-            ThreadLocalRandom random = ThreadLocalRandom.current();
+            RandomGenerator random = RandomGeneratorFactory.getDefault().create(SEED);
             inputstring = new char[size];
             // we want to size the output array with the worst case scenario
             int count = size;
             for(int k = 0; k < size; k++) {
-                inputstring[k] = (char)random.nextInt(0, 256);
+                int value = random.nextInt(0, 256);
+                inputstring[k] = (char)value;
                 if(silly_table3[inputstring[k]] > 0) {
                     count++;
                 }


### PR DESCRIPTION
The changes are described in the comments for the pr, but sommarized:

1. more realistic compilation due saving OSR to happen
2. using random with fixed seed to be more predictable across runs
3. enable loop unrolling in the table case

I didn't checked yet if the non table version got the same problem; numbers look incredibly different (as expected) thanks to loop unrolling 