### PR TITLE
Add raw type 3 benchmarks with brenchless implementations

### DIFF
--- a/2024/10/14/pom.xml
+++ b/2024/10/14/pom.xml
@@ -87,8 +87,9 @@ THE POSSIBILITY OF SUCH DAMAGE.
 
                 <configuration>
                     <compilerVersion>${javac.target}</compilerVersion>
-                    <source>${javac.target}</source>
-                    <target>${javac.target}</target>
+                    <!-- this is needed to use both the Random new API and Long::compress -->
+                    <source>19</source>
+                    <target>19</target>
                     <compilerArgs>
                     <arg>-processor</arg>
                     <arg>org.openjdk.jmh.generators.BenchmarkProcessor</arg>

--- a/2024/10/14/src/main/java/me/lemire/MyBenchmark.java
+++ b/2024/10/14/src/main/java/me/lemire/MyBenchmark.java
@@ -4,7 +4,13 @@ import org.openjdk.jmh.annotations.Benchmark;
 
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
-import java.util.concurrent.ThreadLocalRandom;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.random.RandomGenerator;
+import java.util.random.RandomGeneratorFactory;
 
 @Measurement(iterations = 10, time = 1)
 @Warmup(iterations = 5, time = 1)
@@ -143,6 +149,9 @@ public class MyBenchmark {
     @State(Scope.Benchmark)
     public static class BenchmarkState {
 
+        // better be safe and keep it the same to have reproducible results
+        private static final int SEED = 42;
+
         @Param({"65536"})
         public int size;
         public char[] inputstring;
@@ -151,7 +160,7 @@ public class MyBenchmark {
 
         @Setup(Level.Trial)
         public void setUp() {
-            ThreadLocalRandom random = ThreadLocalRandom.current();
+            RandomGenerator random = RandomGeneratorFactory.getDefault().create(SEED);
             inputstring = new char[size];
             // we want to size the output array with the worst case scenario
             int count = size;
@@ -164,6 +173,163 @@ public class MyBenchmark {
             }
             outputstring = new char[count];
         }
+    }
+
+    @State(Scope.Benchmark)
+    public static class RawBenchmarkState {
+
+        // better be safe and keep it the same to have reproducible results
+        private static final int SEED = 42;
+
+        @Param({"65536"})
+        public int size;
+        public byte[] inputstring;
+        public byte[] outputstring;
+
+
+        @Setup(Level.Trial)
+        public void setUp() {
+            RandomGenerator random = RandomGeneratorFactory.getDefault().create(SEED);
+            inputstring = new byte[size];
+            // we want to size the output array with the worst case scenario
+            int count = size;
+            for(int k = 0; k < size; k++) {
+                int value = random.nextInt(0, 256);
+                inputstring[k] = (byte) value;
+                if(silly_table3[inputstring[k] & 0xFF] > 0) {
+                    count++;
+                }
+            }
+            // always make this at least size + 4 to allow the algorithm to be smarter
+            outputstring = new byte[count + 4];
+        }
+    }
+
+    @Benchmark
+    public void benchReplaceBackslashRawTable3(Blackhole blackhole, RawBenchmarkState state) {
+        blackhole.consume(replaceBackslashRawTable3(state.inputstring, state.outputstring));
+    }
+
+    @Benchmark
+    public void benchReplaceBackslashRawCompressedTable3(Blackhole blackhole, RawBenchmarkState state) {
+        blackhole.consume(replaceBackslashRawCompressedTable3(state.inputstring, state.outputstring));
+    }
+
+    /**
+     * this version looks appealing as it doesn't have branches, but it's a trap!
+     * Looks at the data dependency to compute the index in the output array!<br>
+     * It would be better instead to accumulate 4 output chars in a single long, while keeping track
+     * of the empty slots in another mask and using {@link Long#compress(long, long)} and {@link Long#bitCount(long)}
+     * to compute the index in the output array, while using a single batched store to write the compressed long.
+     * Due to this batched store, we always need to have 7 more additional bytes in the output array.
+     *
+     * We still have a data dependency to know the next index, but in the best case scenario we could advance by 4 at time.
+     */
+    public static int replaceBackslashRawTable3(byte[] original, byte[] newArray) {
+        int newArrayLength = 0;
+        for (byte c : original) {
+            newArrayLength = writeToOutput(newArray, c, newArrayLength);
+        }
+        return newArrayLength;
+    }
+
+    // This can be used to verify that we're not doing something terribly wrong!
+    // It can become just a test, really
+    public static void main(String[] args) {
+        var state = new RawBenchmarkState();
+        state.size = 65536;
+        state.setUp();
+        int out = replaceBackslashRawCompressedTable3(state.inputstring, state.outputstring);
+        byte[] copy = Arrays.copyOf(state.outputstring, out);
+        out = replaceBackslashRaw3(state.inputstring, state.outputstring);
+        // check if the two arrays are the same and print the values and positions which are not
+        byte[] good = Arrays.copyOf(state.outputstring, out);
+        for (int i = 0; i < good.length; i++) {
+            if (good[i] != copy[i]) {
+                System.out.println("Position: " + i + " " + good[i] + " != " + copy[i]);
+            }
+        }
+        System.out.println(Arrays.equals(copy, good));
+    }
+
+    private static final VarHandle LONG_COMPRESS_WRITER = MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
+    private static final VarHandle INT_READER = MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.LITTLE_ENDIAN);
+
+    public static int replaceBackslashRawCompressedTable3(byte[] original, byte[] newArray) {
+        int newArrayLength = 0;
+        int fourCharsBatches = original.length / 4;
+        for (int b = 0; b < fourCharsBatches; b++) {
+            int i = b * 4;
+            long fourChars = 0;
+            long compressMask = 0;
+            int fourReadChars = (int) INT_READER.get(original, i);
+            for (int j = 0; j < 4; j++) {
+                int ch0 = (fourReadChars >>> (j * 8)) & 0xFF;
+                byte b0 = silly_table3[ch0];
+                int zeroIfEqualsZeroOrMinusOneIfNot = ((b0 | -b0) >> 31);
+                // put the jth 2 bytes chars in the right fourChars slots
+                int firstChar = ((~zeroIfEqualsZeroOrMinusOneIfNot & ch0) | (zeroIfEqualsZeroOrMinusOneIfNot & '\\'));
+                int twoChars = (b0 << 8) | firstChar;
+                fourChars |= (long) twoChars << (j * 16);
+                // put the jth 2 bytes mask in the right compressMask slots
+                compressMask |= (long) (~zeroIfEqualsZeroOrMinusOneIfNot & 0xFF00) << (j * 16);
+            }
+            compressMask = ~compressMask;
+            // compress the fourChars into the newArray; this could be the same too!
+            long compressedChars = Long.compress(fourChars, compressMask);
+            LONG_COMPRESS_WRITER.set(newArray, newArrayLength, compressedChars);
+            int chars = Long.bitCount(compressMask) / 8;
+            newArrayLength += chars;
+        }
+        int tail = original.length % 4;
+        for (int t = 0; t < tail; t++) {
+            int i = fourCharsBatches * 4 + t;
+            newArrayLength = writeToOutput(newArray, original[i], newArrayLength);
+        }
+        return newArrayLength;
+    }
+
+    private static final VarHandle SHORT_WRITER = MethodHandles.byteArrayViewVarHandle(short[].class, ByteOrder.LITTLE_ENDIAN);
+
+    private static int writeToOutput(byte[] newArray, byte c, int newArrayLength) {
+        int ch0 = c & 0xFF;
+        byte b0 = silly_table3[ch0];
+        int zeroIfEqualsZeroOrMinusOneIfNot = ((b0 | -b0) >> 31);
+        // branch-less assign \\ if b != 0 or c if b == 0
+        int firstChar = ((~zeroIfEqualsZeroOrMinusOneIfNot & ch0) | (zeroIfEqualsZeroOrMinusOneIfNot & '\\'));
+        short twoChars = (short) ((b0 << 8) | firstChar);
+        SHORT_WRITER.set(newArray, newArrayLength, twoChars);
+        // branch-less increment by 2 if b != 0 or 1 if b == 0
+        newArrayLength += 1 + (zeroIfEqualsZeroOrMinusOneIfNot & 1);
+        return newArrayLength;
+    }
+
+    @Benchmark
+    public void benchReplaceBackslashRaw3(Blackhole blackhole, RawBenchmarkState state) {
+        blackhole.consume(replaceBackslashRaw3(state.inputstring, state.outputstring));
+    }
+
+    public static int replaceBackslashRaw3(byte[] original, byte[] newArray) {
+        int index = 0;
+        for (byte c : original) {
+            if (c == '\\') {
+                newArray[index] = '\\';
+                newArray[index + 1] = '\\';
+                index += 2;
+            } else if (c == '\n') {
+                newArray[index] = '\\';
+                newArray[index + 1] = 'n';
+                index += 2;
+            } else if (c == '\t') {
+                newArray[index] = '\\';
+                newArray[index + 1] = 't';
+                index += 2;
+            } else {
+                newArray[index] = c;
+                index++;
+            }
+        }
+        return index;
     }
 
     @Benchmark


### PR DESCRIPTION
It is (failing) to produce some faster branchless variant, because (likely - but still under investigation):
- the Ryzen 4 branch predictor is exceptionally good - and the fast path is really cheap and can fill the pipeline properly 
- the branchless version trades branches with data dependencies which requires REAL computations to happen
- the "slowest" branchless and batchy variant seems to go out of registers on my poor x86 getting some unecessary spill/unspill which increase a lot the L1 loads (which is no good, despite cheap - in general)

I would like some help to improve the math parth and the analysis to make sure I'm not missing anything @lemire 

And I believe the existing values in the related blog posts should reflect the latest numbers in the benchs (before this PR), because on my Ryzen, the branch predictor just rocks so much that the table approach (which still has 1 more load from the lookup table + RAW dependency more + the usual branch) is just worse.