### PR TITLE
Split replacements and compressionMask ops

### DIFF
--- a/2024/10/14/src/main/java/me/lemire/MyBenchmark.java
+++ b/2024/10/14/src/main/java/me/lemire/MyBenchmark.java
@@ -283,15 +283,41 @@ public class MyBenchmark {
     }
 
     private static long writeReplacementPart(byte[] newArray, int newArrayLength, int readChars) {
-        long compressionMask = 0;
-        long replacements = 0;
-        for (int i = 0; i < 4; i++) {
-            int c = (readChars >>> (i * 8)) & 0xFF;
+        long compressionMask;
+        long replacements;
+        {
+            int c = (readChars >>> (0 * 8)) & 0xFF;
             long replacement = Short.toUnsignedLong(replacementsAndCompressionTables[c * 2]);
             long mask = Short.toUnsignedLong(replacementsAndCompressionTables[(c * 2) + 1]);
-            replacements |= (replacement << (i * 16));
-            compressionMask |= (mask << (i * 16));
+            replacements = (replacement << (0 * 16));
+            compressionMask = (mask << (0 * 16));
         }
+        {
+            int c = (readChars >>> (1 * 8)) & 0xFF;
+            long replacement = Short.toUnsignedLong(replacementsAndCompressionTables[c * 2]);
+            long mask = Short.toUnsignedLong(replacementsAndCompressionTables[(c * 2) + 1]);
+            replacements |= (replacement << (1 * 16));
+            compressionMask |= (mask << (1 * 16));
+        }
+        long compressionMask1;
+        long replacements1;
+        {
+            int c = (readChars >>> (2 * 8)) & 0xFF;
+            long replacement = Short.toUnsignedLong(replacementsAndCompressionTables[c * 2]);
+            long mask = Short.toUnsignedLong(replacementsAndCompressionTables[(c * 2) + 1]);
+            replacements1 = (replacement << (2 * 16));
+            compressionMask1 = (mask << (2 * 16));
+        }
+        {
+            int c = (readChars >>> (3 * 8)) & 0xFF;
+            long replacement = Short.toUnsignedLong(replacementsAndCompressionTables[c * 2]);
+            long mask = Short.toUnsignedLong(replacementsAndCompressionTables[(c * 2) + 1]);
+            replacements1 |= (replacement << (3 * 16));
+            compressionMask1 |= (mask << (3 * 16));
+        }
+        // merge both replacements and compression masks
+        replacements |= replacements1;
+        compressionMask |= compressionMask1;
         LONG_WRITER.set(newArray, newArrayLength, Long.compress(replacements, compressionMask));
         return compressionMask;
     }


### PR DESCRIPTION
This is further pushing performance, on my Intel:
```
Benchmark                                                                   (size)  (specialCharPercentage)   Mode  Cnt       Score     Error      Units
MyBenchmark.benchReplaceBackslashRawCompressedTable3                         65536                        3  thrpt   20   25213.335 ± 372.418      ops/s
MyBenchmark.benchReplaceBackslashRawCompressedTable3:CPI                     65536                        3  thrpt    2       0.238            clks/insn
MyBenchmark.benchReplaceBackslashRawCompressedTable3:IPC                     65536                        3  thrpt    2       4.194            insns/clk
MyBenchmark.benchReplaceBackslashRawCompressedTable3:L1-dcache-load-misses   65536                        3  thrpt    2    2146.035                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:L1-dcache-loads         65536                        3  thrpt    2  164026.578                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:L1-dcache-stores        65536                        3  thrpt    2   16505.070                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:L1-icache-load-misses   65536                        3  thrpt    2      22.950                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:LLC-load-misses         65536                        3  thrpt    2       0.546                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:LLC-loads               65536                        3  thrpt    2       1.984                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:LLC-store-misses        65536                        3  thrpt    2       0.086                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:LLC-stores              65536                        3  thrpt    2       0.870                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:branch-misses           65536                        3  thrpt    2      12.685                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:branches                65536                        3  thrpt    2   24691.456                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:cycles                  65536                        3  thrpt    2  187393.720                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:dTLB-load-misses        65536                        3  thrpt    2       0.200                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:dTLB-loads              65536                        3  thrpt    2  164210.209                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:dTLB-store-misses       65536                        3  thrpt    2       0.215                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:dTLB-stores             65536                        3  thrpt    2   16488.149                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:iTLB-load-misses        65536                        3  thrpt    2       1.172                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:instructions            65536                        3  thrpt    2  785894.742                 #/op
```
while it was:
```
Benchmark                                                                   (size)  (specialCharPercentage)   Mode  Cnt       Score     Error      Units
MyBenchmark.benchReplaceBackslashRawCompressedTable3                         65536                        3  thrpt   20   21935.548 ± 340.203      ops/s
MyBenchmark.benchReplaceBackslashRawCompressedTable3:CPI                     65536                        3  thrpt    2       0.258            clks/insn
MyBenchmark.benchReplaceBackslashRawCompressedTable3:IPC                     65536                        3  thrpt    2       3.881            insns/clk
MyBenchmark.benchReplaceBackslashRawCompressedTable3:L1-dcache-load-misses   65536                        3  thrpt    2    2151.014                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:L1-dcache-loads         65536                        3  thrpt    2  180538.735                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:L1-dcache-stores        65536                        3  thrpt    2   16516.993                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:L1-icache-load-misses   65536                        3  thrpt    2      30.914                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:LLC-load-misses         65536                        3  thrpt    2       0.441                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:LLC-loads               65536                        3  thrpt    2       2.071                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:LLC-store-misses        65536                        3  thrpt    2       0.108                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:LLC-stores              65536                        3  thrpt    2       1.211                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:branch-misses           65536                        3  thrpt    2       3.999                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:branches                65536                        3  thrpt    2   24711.769                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:cycles                  65536                        3  thrpt    2  215485.048                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:dTLB-load-misses        65536                        3  thrpt    2       0.212                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:dTLB-loads              65536                        3  thrpt    2  180093.616                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:dTLB-store-misses       65536                        3  thrpt    2       0.281                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:dTLB-stores             65536                        3  thrpt    2   16475.620                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:iTLB-load-misses        65536                        3  thrpt    2       1.356                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:instructions            65536                        3  thrpt    2  836267.589                 #/op

```

The assembly produced is now
```assembly
  0x00007fb0b01e05a1:   mov    %eax,%ecx
  0x00007fb0b01e05a3:   lea    0x0(,%r8,8),%r11d
  0x00007fb0b01e05ab:   vmovq  %xmm0,%r10
  0x00007fb0b01e05b0:   mov    0x10(%r10,%r11,1),%r11
  0x00007fb0b01e05b5:   mov    %r11d,%edx
  0x00007fb0b01e05b8:   movzbl %dl,%r9d
  0x00007fb0b01e05bc:   mov    %edx,%esi
  0x00007fb0b01e05be:   shr    $0x17,%esi
  0x00007fb0b01e05c1:   shl    %r9d
  0x00007fb0b01e05c4:   movzwq 0x12(%rbx,%r9,2),%rdi
  0x00007fb0b01e05ca:   movzwq 0x10(%rbx,%r9,2),%rax
  0x00007fb0b01e05d0:   and    $0xfffffffe,%esi
  0x00007fb0b01e05d3:   movzwq 0x12(%rbx,%rsi,2),%rbp
  0x00007fb0b01e05d9:   movzwq 0x10(%rbx,%rsi,2),%r9
  0x00007fb0b01e05df:   mov    %edx,%r10d
  0x00007fb0b01e05e2:   shr    $0xf,%r10d
  0x00007fb0b01e05e6:   shl    $0x30,%r9
  0x00007fb0b01e05ea:   and    $0x1fe,%r10d
  0x00007fb0b01e05f1:   movzwq 0x12(%rbx,%r10,2),%rsi
  0x00007fb0b01e05f7:   movzwq 0x10(%rbx,%r10,2),%r10
  0x00007fb0b01e05fd:   shl    $0x30,%rbp
  0x00007fb0b01e0601:   shl    $0x20,%r10
  0x00007fb0b01e0605:   or     %r9,%r10
  0x00007fb0b01e0608:   shl    $0x20,%rsi
  0x00007fb0b01e060c:   or     %rbp,%rsi
  0x00007fb0b01e060f:   shr    $0x7,%edx
  0x00007fb0b01e0612:   and    $0x1fe,%edx
  0x00007fb0b01e0618:   movzwq 0x12(%rbx,%rdx,2),%r9
  0x00007fb0b01e061e:   movzwq 0x10(%rbx,%rdx,2),%rdx
  0x00007fb0b01e0624:   shl    $0x10,%r9
  0x00007fb0b01e0628:   or     %r9,%rdi
  0x00007fb0b01e062b:   or     %rsi,%rdi
  0x00007fb0b01e062e:   shl    $0x10,%rdx
  0x00007fb0b01e0632:   or     %rdx,%rax
  0x00007fb0b01e0635:   or     %r10,%rax
  0x00007fb0b01e0638:   pext   %rdi,%rax,%r10
  0x00007fb0b01e063d:   cmp    0x38(%rsp),%ecx
  0x00007fb0b01e0641:   jae    0x00007fb0b01e079f
  0x00007fb0b01e0647:   shr    $0x20,%r11
  0x00007fb0b01e064b:   mov    %r11d,%edx
  0x00007fb0b01e064e:   movslq %ecx,%rsi
  0x00007fb0b01e0651:   vmovq  %xmm1,%r11
  0x00007fb0b01e0656:   mov    %r10,0x10(%r11,%rsi,1)
  0x00007fb0b01e065b:   movzbl %dl,%r11d
  0x00007fb0b01e065f:   mov    %edx,%eax
  0x00007fb0b01e0661:   shr    $0x17,%eax
  0x00007fb0b01e0664:   shl    %r11d
  0x00007fb0b01e0667:   movzwq 0x12(%rbx,%r11,2),%r9
  0x00007fb0b01e066d:   movzwq 0x10(%rbx,%r11,2),%rbp
  0x00007fb0b01e0673:   and    $0xfffffffe,%eax
  0x00007fb0b01e0676:   movzwq 0x12(%rbx,%rax,2),%r10
  0x00007fb0b01e067c:   movzwq 0x10(%rbx,%rax,2),%r14
  0x00007fb0b01e0682:   mov    %edx,%r11d
  0x00007fb0b01e0685:   shr    $0xf,%r11d
  0x00007fb0b01e0689:   shl    $0x30,%r14                   ;   {no_reloc}
  0x00007fb0b01e068d:   and    $0x1fe,%r11d
  0x00007fb0b01e0694:   movzwq 0x12(%rbx,%r11,2),%rax
  0x00007fb0b01e069a:   movzwq 0x10(%rbx,%r11,2),%r13
  0x00007fb0b01e06a0:   shl    $0x30,%r10
  0x00007fb0b01e06a4:   shl    $0x20,%r13
  0x00007fb0b01e06a8:   or     %r14,%r13
  0x00007fb0b01e06ab:   shl    $0x20,%rax
  0x00007fb0b01e06af:   or     %r10,%rax
  0x00007fb0b01e06b2:   shr    $0x7,%edx
  0x00007fb0b01e06b5:   popcnt %rdi,%r11
  0x00007fb0b01e06ba:   and    $0x1fe,%edx
  0x00007fb0b01e06c0:   movzwq 0x12(%rbx,%rdx,2),%rdi
  0x00007fb0b01e06c6:   movzwq 0x10(%rbx,%rdx,2),%rdx
  0x00007fb0b01e06cc:   mov    %r11d,%r10d
  0x00007fb0b01e06cf:   sar    $0x1f,%r10d
  0x00007fb0b01e06d3:   shl    $0x10,%rdx
  0x00007fb0b01e06d7:   or     %rdx,%rbp
  0x00007fb0b01e06da:   or     %r13,%rbp
  0x00007fb0b01e06dd:   shr    $0x1d,%r10d
  0x00007fb0b01e06e1:   add    %r11d,%r10d
  0x00007fb0b01e06e4:   shl    $0x10,%rdi
  0x00007fb0b01e06e8:   or     %rdi,%r9
  0x00007fb0b01e06eb:   or     %rax,%r9
  0x00007fb0b01e06ee:   pext   %r9,%rbp,%rdi
  0x00007fb0b01e06f3:   sar    $0x3,%r10d
  0x00007fb0b01e06f7:   lea    (%rcx,%r10,1),%r11d
  0x00007fb0b01e06fb:   cmp    0x38(%rsp),%r11d
  0x00007fb0b01e0700:   jae    0x00007fb0b01e07d4
  0x00007fb0b01e0706:   popcnt %r9,%r11
  0x00007fb0b01e070b:   movslq %r10d,%r9
  0x00007fb0b01e070e:   add    %rsi,%r9
  0x00007fb0b01e0711:   vmovq  %xmm1,%rdx
  0x00007fb0b01e0716:   mov    %rdi,0x10(%rdx,%r9,1)
  0x00007fb0b01e071b:   mov    %r11d,%eax
  0x00007fb0b01e071e:   sar    $0x1f,%eax
  0x00007fb0b01e0721:   shr    $0x1d,%eax
  0x00007fb0b01e0724:   add    %r11d,%eax
  0x00007fb0b01e0727:   sar    $0x3,%eax
  0x00007fb0b01e072a:   add    %r10d,%eax
  0x00007fb0b01e072d:   add    %ecx,%eax
  0x00007fb0b01e072f:   inc    %r8d
  0x00007fb0b01e0732:   cmp    (%rsp),%r8d
  0x00007fb0b01e0736:   jl     0x00007fb0b01e05a
```
which shows few things vs the original code at https://github.com/lemire/Code-used-on-Daniel-Lemire-s-blog/pull/113#issuecomment-2565106627:
- the addition on the input position (performed by a shift by 3 now replaced by a lea + 8)
- there are no `vmovd` now and the input register is `r8` without any "spill" into `xmm3`
- the first `popcnt`  happen much later than it was to be (!!!)  
- the original asm was using separate registers to hold the intermediate lookups (replacements and compressions) using few dependent `or`s right before `pext` - while now it perform the intermediate `or`s