### PR TITLE
Moving to use a single lookup table

### DIFF
--- a/2024/10/14/src/main/java/me/lemire/MyBenchmark.java
+++ b/2024/10/14/src/main/java/me/lemire/MyBenchmark.java
@@ -35,20 +35,16 @@ public class MyBenchmark {
     }
 
     private static final byte[] silly_table3;
-    private static final short[] replacementsAndLengthsTables = new short[256 * 2];
+    private static final int[] replacements = new int[256];
 
     static {
         for (int i = 0; i < 256; i++) {
-            replacementsAndLengthsTables[i * 2] = (short) (i & 0xFF);
-            replacementsAndLengthsTables[(i * 2) + 1] = 1;
+            replacements[i] = (i & 0xFF) | (1 << 16);
         }
         // we need to override the default values
-        replacementsAndLengthsTables['\\' * 2] = (short) (0x005c | (('\\' & 0xFF) << 8));
-        replacementsAndLengthsTables[('\\' * 2) + 1] = 2;
-        replacementsAndLengthsTables['\n' * 2] = (short) (0x005c | (('n' & 0xFF) << 8));
-        replacementsAndLengthsTables[('\n' * 2) + 1] = 2;
-        replacementsAndLengthsTables['\t' * 2] = (short) (0x005c | (('t' & 0xFF) << 8));
-        replacementsAndLengthsTables[('\t' * 2) + 1] = 2;
+        replacements['\\'] = (0x005c | (('\\' & 0xFF) << 8)) | (2 << 16);
+        replacements['\n'] = (0x005c | (('n' & 0xFF) << 8)) | (2 << 16);
+        replacements['\t'] = (0x005c | (('t' & 0xFF) << 8)) | (2 << 16);
 
         silly_table3 = new byte[256];
         silly_table3['\\'] = '\\';
@@ -263,9 +259,11 @@ public class MyBenchmark {
         int outputOffset = 0;
         for (byte b : original) {
             int latin = b & 0xFF;
-            short replacement = replacementsAndLengthsTables[2 * latin];
+            int replacementAndLength = replacements[latin];
+            short replacement = (short) replacementAndLength;
             SHORT_WRITER.set(newArray, outputOffset, replacement);
-            outputOffset += replacementsAndLengthsTables[(2 * latin) + 1];
+            int length =  replacementAndLength >> 16;
+            outputOffset += length;
         }
         return outputOffset;
     }


### PR DESCRIPTION
This is funny here - on Ryzen, the existing code produce this performance

```
Benchmark                                                                     (size)  (specialCharPercentage)   Mode  Cnt       Score    Error      Units
MyBenchmark.benchReplaceBackslashRawCompressedTable3                           65536                        0  thrpt   20   26783.951 ± 66.355      ops/s
MyBenchmark.benchReplaceBackslashRawCompressedTable3:CPI                       65536                        0  thrpt    2       0.297           clks/insn
MyBenchmark.benchReplaceBackslashRawCompressedTable3:IPC                       65536                        0  thrpt    2       3.370           insns/clk
MyBenchmark.benchReplaceBackslashRawCompressedTable3:L1-dcache-load-misses     65536                        0  thrpt    2    2118.079                #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:L1-dcache-loads           65536                        0  thrpt    2  263567.211                #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:L1-icache-load-misses     65536                        0  thrpt    2       0.594                #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:L1-icache-loads           65536                        0  thrpt    2     268.828                #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:branch-misses             65536                        0  thrpt    2      34.027                #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:branches                  65536                        0  thrpt    2   82121.699                #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:cycles                    65536                        0  thrpt    2  204572.765                #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:dTLB-load-misses          65536                        0  thrpt    2       0.073                #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:dTLB-loads                65536                        0  thrpt    2       4.141                #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:iTLB-load-misses          65536                        0  thrpt    2       0.256                #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:iTLB-loads                65536                        0  thrpt    2       0.192                #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:instructions              65536                        0  thrpt    2  689362.358                #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:stalled-cycles-frontend   65536                        0  thrpt    2     766.591                #/op
```
which is decent and near to what can be obtained with the existing table approach when there are no special chars - but still is underperforming compared to the whoopy 33K with newish Intel - which seems able to perform 2 lookups in parallel, for each read char.
For comparison - the closed pr at https://github.com/lemire/Code-used-on-Daniel-Lemire-s-blog/pull/114 with Ryzen, was overperforming the existing approach with Intel - even if not by a great margin i.e. ~28K ops/sec

Moving to a single table lookup with Ryzen (4) the performance is the best we could achieve i.e.

```
Benchmark                                                                     (size)  (specialCharPercentage)   Mode  Cnt       Score     Error      Units
MyBenchmark.benchReplaceBackslashRawCompressedTable3                           65536                        0  thrpt   20   38490.297 ± 225.671      ops/s
MyBenchmark.benchReplaceBackslashRawCompressedTable3:CPI                       65536                        0  thrpt    2       0.186            clks/insn
MyBenchmark.benchReplaceBackslashRawCompressedTable3:IPC                       65536                        0  thrpt    2       5.369            insns/clk
MyBenchmark.benchReplaceBackslashRawCompressedTable3:L1-dcache-load-misses     65536                        0  thrpt    2    2098.366                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:L1-dcache-loads           65536                        0  thrpt    2  197925.670                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:L1-icache-load-misses     65536                        0  thrpt    2       0.656                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:L1-icache-loads           65536                        0  thrpt    2     216.512                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:branch-misses             65536                        0  thrpt    2      30.163                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:branches                  65536                        0  thrpt    2   82099.583                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:cycles                    65536                        0  thrpt    2  140648.734                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:dTLB-load-misses          65536                        0  thrpt    2       0.171                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:dTLB-loads                65536                        0  thrpt    2       3.432                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:iTLB-load-misses          65536                        0  thrpt    2       0.204                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:iTLB-loads                65536                        0  thrpt    2       0.195                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:instructions              65536                        0  thrpt    2  755059.926                 #/op
MyBenchmark.benchReplaceBackslashRawCompressedTable3:stalled-cycles-frontend   65536                        0  thrpt    2     589.245                 #/op
```
IPC now is much better and `L1-dcache-loads ` are way less - as expected.

I'll give it a shot on Intel to see how it performs - but I start to think we're moving in a land where the CPU frontend design matter enough to give very different outcome with small changes in code